### PR TITLE
Fixes a memory leak in Psych parser

### DIFF
--- a/ext/psych/parser.c
+++ b/ext/psych/parser.c
@@ -304,6 +304,7 @@ static VALUE parse(VALUE self, VALUE yaml)
 	    done = 1;
 	    break;
 	}
+	yaml_event_delete(&event);
     }
 
     return self;


### PR DESCRIPTION
Release memory associated with yaml_event using yaml_event_delete at bottom of parse event loop.

Test stubs and valgrind shell helper script available in 'fix memory leak' branch.

Example output is:

```
~/psych/memtest# ./valgrind.sh
== Ruby 1.9.2 w/ Psych 1.0.0 ==
==9122== Memcheck, a memory error detector
==9122== Copyright (C) 2002-2010, and GNU GPL'd, by Julian Seward et al.
==9122== Using Valgrind-3.6.0.SVN-Debian and LibVEX; rerun with -h for copyright info
==9122== Command: /usr/bin/ruby1.9 testleak_rb19_psych_1_0_0.rb
==9122==
YAML yamler: Psych
Psych version: 1.0.0
..........==9122==
==9122== HEAP SUMMARY:
==9122==     in use at exit: 2,735,128 bytes in 34,303 blocks
==9122==   total heap usage: 314,119 allocs, 279,816 frees, 15,869,850 bytes allocated
==9122==
==9122== LEAK SUMMARY:
==9122==    definitely lost: 828,964 bytes in 10,011 blocks
==9122==    indirectly lost: 1,120 bytes in 70 blocks
==9122==      possibly lost: 251,969 bytes in 6,050 blocks
==9122==    still reachable: 1,653,075 bytes in 18,172 blocks
==9122==         suppressed: 0 bytes in 0 blocks
==9122== Rerun with --leak-check=full to see details of leaked memory
==9122==
==9122== For counts of detected and suppressed errors, rerun with: -v
==9122== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
== Ruby 1.9.2 w/ Psych Gem 1.1.1 ==
==9128== Memcheck, a memory error detector
==9128== Copyright (C) 2002-2010, and GNU GPL'd, by Julian Seward et al.
==9128== Using Valgrind-3.6.0.SVN-Debian and LibVEX; rerun with -h for copyright info
==9128== Command: /usr/bin/ruby1.9 testleak_psych_1_1_1.rb
==9128==
YAML yamler: Psych
Psych version: 1.1.1
..........==9128==
==9128== HEAP SUMMARY:
==9128==     in use at exit: 2,757,306 bytes in 39,104 blocks
==9128==   total heap usage: 362,499 allocs, 323,395 frees, 22,216,738 bytes allocated
==9128==
==9128== LEAK SUMMARY:
==9128==    definitely lost: 160,004 bytes in 10,001 blocks
==9128==    indirectly lost: 0 bytes in 0 blocks
==9128==      possibly lost: 397,383 bytes in 8,405 blocks
==9128==    still reachable: 2,199,919 bytes in 20,698 blocks
==9128==         suppressed: 0 bytes in 0 blocks
==9128== Rerun with --leak-check=full to see details of leaked memory
==9128==
==9128== For counts of detected and suppressed errors, rerun with: -v
==9128== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
== Ruby 1.9.2 w/ Psych Gem 1.1.1.mjtko1 ==
==9135== Memcheck, a memory error detector
==9135== Copyright (C) 2002-2010, and GNU GPL'd, by Julian Seward et al.
==9135== Using Valgrind-3.6.0.SVN-Debian and LibVEX; rerun with -h for copyright info
==9135== Command: /usr/bin/ruby1.9 testleak_psych_1_1_1_mjtko1.rb
==9135==
YAML yamler: Psych
Psych version: 1.1.1.mjtko1
..........==9135==
==9135== HEAP SUMMARY:
==9135==     in use at exit: 2,600,622 bytes in 29,106 blocks
==9135==   total heap usage: 362,511 allocs, 333,405 frees, 22,240,871 bytes allocated
==9135==
==9135== LEAK SUMMARY:
==9135==    definitely lost: 20 bytes in 2 blocks
==9135==    indirectly lost: 0 bytes in 0 blocks
==9135==      possibly lost: 386,772 bytes in 8,171 blocks
==9135==    still reachable: 2,213,830 bytes in 20,933 blocks
==9135==         suppressed: 0 bytes in 0 blocks
==9135== Rerun with --leak-check=full to see details of leaked memory
==9135==
==9135== For counts of detected and suppressed errors, rerun with: -v
==9135== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Clearly things have improved in psych between 1.0.0 (ruby 1.9p180) and 1.1.1 (and, thus, things have improved in ruby-core trunk) - the leak in psych as distributed with ruby-core lead me to start analyzing under valgrind and I discovered that, while the primary cause of leaks in 1.0.0 had been rectified, a leak does still remain.

This pull request contains a one-line patch that plugs that leak. :)
