### PR TITLE
postfix rescue statement cannot receive Exception class specification.

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -74,13 +74,19 @@ module Psych
         end
         i
       when FLOAT
-        return Float(string.gsub(/[,_]/, '')) rescue ArgumentError
+        begin
+          return Float(string.gsub(/[,_]/, ''))
+        rescue ArgumentError
+        end
 
         @string_cache[string] = true
         string
       else
         if string.count('.') < 2
-          return Integer(string.gsub(/[,_]/, '')) rescue ArgumentError
+          begin
+            return Integer(string.gsub(/[,_]/, ''))
+          rescue ArgumentError
+          end
         end
 
         @string_cache[string] = true


### PR DESCRIPTION
the statements in scalar_scanner.rb like

return Float(...) rescue ArgumentError

seems to intend as follows. Doesn't it?

begin
  Float(...)
rescue ArgumentError
end

But it's equivalent with

begin
  Float(...)
rescue
  ArgumentError
end

Fortunately, Float()/Integer() never raise exception except ArgumentError when an argument is a String, so this trivial difference don't matter in this case. So I don't know how to write unit test for it.
