### PR TITLE
Link to libyaml's website in README was incorrect. 

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,7 +4,7 @@
 
 == Description
 
-Psych is a YAML parser and emitter.  Psych leverages libyaml[http://libyaml.org]
+Psych is a YAML parser and emitter.  Psych leverages libyaml[http://pyyaml.org/wiki/LibYAML]
 for its YAML parsing and emitting capabilities.  In addition to wrapping
 libyaml, Psych also knows how to serialize and de-serialize most Ruby objects
 to and from the YAML format.


### PR DESCRIPTION
Was http://libyaml.org changed to http://pyyaml.org/wiki/LibYAML . 

libyaml.org doesn't seem to be a real website. 
