### PR TITLE
add missing #warn in #init_with for #yaml_initialize deprecation

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -285,7 +285,7 @@ module Psych
           o.init_with c
         elsif o.respond_to?(:yaml_initialize)
           if $VERBOSE
-            "Implementing #{o.class}#yaml_initialize is deprecated, please implement \"init_with(coder)\""
+            warn "Implementing #{o.class}#yaml_initialize is deprecated, please implement \"init_with(coder)\""
           end
           o.yaml_initialize c.tag, c.map
         else


### PR DESCRIPTION
Hello,
I found the deprecation message when #yaml_initialize is defined (and not #init_with) is never outputed, due to a missing `puts` or `warn`.

By the way, what is the recommended way to be compatible with all YAML implementations for loading (and dumping) custom classes?
Defining both #yaml_initialize and #init_with ? Is there some documentation on this?

In my case, the default Object dumper/loader works fine, except for the `frozen?` status (the loaded object is no more `frozen?`).
