### PR TITLE
Updated lib/psych.rb

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -200,7 +200,7 @@ module Psych
   def self.parse_stream yaml, filename = nil, &block
     if block_given?
       parser = Psych::Parser.new(Handlers::DocumentStream.new(&block))
-      parser.parse yaml, filename
+      parser.parse yaml
     else
       parser = self.parser
       parser.parse yaml, filename


### PR DESCRIPTION
Recent modification broke postrank-uri's yaml reading, DocumentStream's parse-method takes a single argument.
I applied the fix locally and the bug was resolved.
