### PR TITLE
Solve an error using 'rails db'

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -251,19 +251,19 @@ module Psych
           o.children.each_slice(2) { |k,v|
           key = accept(k)
 
-          if key == '<<'
+          if key == '<<' and av = accept(v)
             case v
             when Nodes::Alias
-              hash.merge! accept(v)
+              hash.merge! av
             when Nodes::Sequence
               accept(v).reverse_each do |value|
                 hash.merge! value
               end
             else
-              hash[key] = accept(v)
+              hash[key] = av
             end
           else
-            hash[key] = accept(v)
+            hash[key] = av
           end
 
         }


### PR DESCRIPTION
Calling 'rails db' causes ==>

  /home/akt/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:221:in `merge!': can't convert nil into Hash (TypeError)

Line 221 at my version equates to line 257 at the version I patch here.
Applying my patch the error removed and the console opened.
