### PR TITLE
Fix scalar_scanner to understand strings starting with an underscore and containing only digits

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -24,7 +24,7 @@ module Psych
       return string if @string_cache.key?(string)
 
       case string
-      when /^[A-Za-z~]/
+      when /^[A-Za-z_~]/
         if string.length > 5
           @string_cache[string] = true
           return string

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -87,5 +87,9 @@ module Psych
     def test_scan_true
       assert_equal true, ss.tokenize('true')
     end
+
+    def test_scan_strings_starting_with_underscores
+      assert_equal "_100", ss.tokenize('_100')
+    end
   end
 end


### PR DESCRIPTION
Title is self-explanatory
