### PR TITLE
Ignore bad timestamps

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -45,7 +45,11 @@ module Psych
           string
         end
       when TIME
-        parse_time string
+        begin
+          parse_time string
+        rescue ArgumentError
+          string
+        end
       when /^\d{4}-(?:1[012]|0\d|\d)-(?:[12]\d|3[01]|0\d|\d)$/
         require 'date'
         begin

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -21,6 +21,17 @@ module Psych
       end
     end
 
+    def test_scan_bad_time
+      [ '2001-12-15T02:59:73.1Z',
+        '2001-12-14t90:59:43.10-05:00',
+        '2001-92-14 21:59:43.10 -5',
+        '2001-12-15 92:59:43.10',
+        '2011-02-24 81:17:06 -0800',
+      ].each do |time_str|
+        assert_equal time_str, @ss.tokenize(time_str)
+      end
+    end
+
     def test_scan_bad_dates
       x = '2000-15-01'
       assert_equal x, @ss.tokenize(x)


### PR DESCRIPTION
If something looks like a timestamp but has an invalid component, treat it as a string instead of throwing an ArgumentError.

This addresses issue #82.
