### PR TITLE
Cache symbols while tokenizing.

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -16,12 +16,14 @@ module Psych
     # Create a new scanner
     def initialize
       @string_cache = {}
+      @symbol_cache = {}
     end
 
     # Tokenize +string+ returning the ruby object
     def tokenize string
       return nil if string.empty?
       return string if @string_cache.key?(string)
+      return @symbol_cache[string] if @symbol_cache.key?(string)
 
       case string
       # Check for a String type, being careful not to get caught by hash keys, hex values, and
@@ -67,9 +69,9 @@ module Psych
         0.0 / 0.0
       when /^:./
         if string =~ /^:(["'])(.*)\1/
-          $2.sub(/^:/, '').to_sym
+          @symbol_cache[string] = $2.sub(/^:/, '').to_sym
         else
-          string.sub(/^:/, '').to_sym
+          @symbol_cache[string] = string.sub(/^:/, '').to_sym
         end
       when /^[-+]?[0-9][0-9_]*(:[0-5]?[0-9])+$/
         i = 0


### PR DESCRIPTION
This cut the number of Regexp comparisons roughly in half on the YAML file in #84 and around 18% on a VCR file I've been testing with.  In both cases the cache didn't grow very large (i.e., the set of symbols was small but repeated).  If memory growth is a concern, I could reimplement as an LRU cache.  But relative to the rest of the parser, it seems like a minor overhead.
