### PR TITLE
Document deprecation of Psych.load_documents

### DIFF
--- a/lib/psych/deprecated.rb
+++ b/lib/psych/deprecated.rb
@@ -21,6 +21,7 @@ module Psych
     target.psych_to_yaml unless opts[:nodump]
   end
 
+  # This method is deprecated, use Psych.load_stream instead.
   def self.load_documents yaml, &block
     if $VERBOSE
       warn "#{caller[0]}: load_documents is deprecated, use load_stream"


### PR DESCRIPTION
The deprecation should be mentioned in the documentation.

I was trying to figure out how load_documents works and was puzzled
that nothing showed up in the docs. Had to look into the source to notice
the deprecation.
