### PR TITLE
Use literal style when emitting multiline strings, fixes #64 

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -230,15 +230,18 @@ module Psych
         plain = false
         quote = false
         style = Nodes::Scalar::ANY
+        tag   = nil
+        str   = o
 
         if binary?(o)
           str   = [o].pack('m').chomp
           tag   = '!binary' # FIXME: change to below when syck is removed
           #tag   = 'tag:yaml.org,2002:binary'
           style = Nodes::Scalar::LITERAL
+        elsif o =~ /\n/
+          quote = true
+          style = Nodes::Scalar::LITERAL
         else
-          str   = o
-          tag   = nil
           quote = !(String === @ss.tokenize(o))
           plain = !quote
         end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1266,4 +1266,9 @@ EOY
       Psych.load("2000-01-01 00:00:00.#{"0"*1000} +00:00\n")
       # '[ruby-core:13735]'
     end
+
+    def test_multiline_string_uses_literal_style
+      yaml = Psych.dump("multi\nline\nstring")
+      assert_match("|", yaml)
+    end
 end


### PR DESCRIPTION
See https://github.com/tenderlove/psych/issues/64 for details.
