### PR TITLE
Strings that start with non-word characters should double quote without exclamation mark

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -242,6 +242,9 @@ module Psych
         elsif o =~ /\n/
           quote = true
           style = Nodes::Scalar::LITERAL
+        elsif o =~ /^\W/
+          quote = true
+          style = Nodes::Scalar::DOUBLE_QUOTED
         else
           quote = !(String === @ss.tokenize(o))
           plain = !quote

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1271,4 +1271,10 @@ EOY
       yaml = Psych.dump("multi\nline\nstring")
       assert_match("|", yaml)
     end
+
+    def test_string_starting_with_non_word_character_uses_double_quotes_without_exclamation_mark
+      yaml = Psych.dump("@123'abc")
+      assert_match("\"", yaml)
+      refute_match("!", yaml)
+    end
 end


### PR DESCRIPTION
``` ruby
Psych.dump("@123'abc")
```

Before this commit:

``` yaml
--- ! '@123''abc'
```

After this commit:

``` yaml
--- "@123'abc"
```

This makes yaml output look much cleaner.
