### PR TITLE
Preserve specified time offsets from YAML

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -143,7 +143,7 @@ module Psych
         offset += ((tz[1] || 0) * 60)
       end
 
-      klass.at((time - offset).to_i, us)
+      klass.new(yy, m, dd, hh, mm, ss+us/1000000, offset)
     end
   end
 end


### PR DESCRIPTION
This change causes parse_time function to return a Ruby Time object with an offset specified in the parsed YAML. I've been playing with Jekyll which leverages Pysch for parsing YAML data in posts and it would be nice to have Time objects extracted from posts respect the offset specified in the YAML front matter. Then, I could either display it with the specified time offset, convert it to utc with the Time::utc, or convert it to local time with Time::getlocal. This seems to me to be a little bit better behavior, but there may be a good reason not to do this that I'm not aware of.
