### PR TITLE
Fix case when map includes a symbol key in #emit_coder

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -440,7 +440,7 @@ module Psych
         when :map
           @emitter.start_mapping nil, c.tag, c.implicit, c.style
           c.map.each do |k,v|
-            @emitter.scalar k, nil, nil, true, false, Nodes::Scalar::ANY
+            accept k
             accept v
           end
           @emitter.end_mapping

--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -85,7 +85,7 @@ module Psych
       end
 
       def encode_with coder
-        coder.represent_map self.class.name, { 'a' => 'b' }
+        coder.represent_map self.class.name, { "string" => 'a', :symbol => 'b' }
       end
     end
 
@@ -131,7 +131,7 @@ module Psych
 
     def test_represent_map
       thing = Psych.load(Psych.dump(RepresentWithMap.new))
-      assert_equal({ 'a' => 'b' }, thing.map)
+      assert_equal({ "string" => 'a', :symbol => 'b' }, thing.map)
     end
 
     def test_represent_sequence


### PR DESCRIPTION
Mimic what is done in #visit_Hash. Fixes #107.
