### PR TITLE
fix 'intendation' typo

### DIFF
--- a/ext/psych/yaml/yaml.h
+++ b/ext/psych/yaml/yaml.h
@@ -1851,7 +1851,7 @@ YAML_DECLARE(void)
 yaml_emitter_set_canonical(yaml_emitter_t *emitter, int canonical);
 
 /**
- * Set the intendation increment.
+ * Set the indentation increment.
  *
  * @param[in,out]   emitter     An emitter object.
  * @param[in]       indent      The indentation increment (1 < . < 10).


### PR DESCRIPTION
Initially found an `intendation` typo at one of `Jekyll` 's error messages, was scouring some repos to figure where its originating. Turns out this one has the same typo error.
