### PR TITLE
Psych.safe_load relies on ClassLoader without explicit dependency

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -14,6 +14,7 @@ require 'psych/stream'
 require 'psych/json/tree_builder'
 require 'psych/json/stream'
 require 'psych/handlers/document_stream'
+require 'psych/class_loader'
 
 ###
 # = Overview


### PR DESCRIPTION
I'm seeing the following when invoking `safe_load` in certain places:

```
NameError: uninitialized constant Psych::ClassLoader
# /Users/ben/.rvm/gems/ruby-1.9.3-p448/gems/psych-2.0.2/lib/psych.rb:286:in `safe_load'
```
