### PR TITLE
backport from libyaml-1.1.6

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,8 @@
+2014-03-27  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
+
+	* ext/psych/yaml/scanner.c: merge libyaml 0.1.6
+	* ext/psych/yaml/yaml_private.h: ditto
+
 Sat Mar  1 11:08:00 2014  Aaron Patterson <aaron@tenderlovemaking.com>
 
 	* ext/psych/lib/psych/visitors/yaml_tree.rb: support dumping Encoding

--- a/ext/psych/yaml/config.h
+++ b/ext/psych/yaml/config.h
@@ -1,11 +1,10 @@
-
 #define PACKAGE_NAME "yaml"
 #define PACKAGE_TARNAME "yaml"
-#define PACKAGE_VERSION "0.1.5"
-#define PACKAGE_STRING "yaml 0.1.5"
+#define PACKAGE_VERSION "0.1.6"
+#define PACKAGE_STRING "yaml 0.1.6"
 #define PACKAGE_BUGREPORT "http://pyyaml.org/newticket?component libyaml"
 #define PACKAGE_URL ""
 #define YAML_VERSION_MAJOR 0
 #define YAML_VERSION_MINOR 1
-#define YAML_VERSION_PATCH 5
-#define YAML_VERSION_STRING "0.1.5"
+#define YAML_VERSION_PATCH 6
+#define YAML_VERSION_STRING "0.1.6"

--- a/ext/psych/yaml/scanner.c
+++ b/ext/psych/yaml/scanner.c
@@ -2629,6 +2629,9 @@ yaml_parser_scan_tag_uri(yaml_parser_t *parser, int directive,
         /* Check if it is a URI-escape sequence. */
 
         if (CHECK(parser->buffer, '%')) {
+            if (!STRING_EXTEND(parser, string))
+                goto error;
+
             if (!yaml_parser_scan_uri_escapes(parser,
                         directive, start_mark, &string)) goto error;
         }

--- a/ext/psych/yaml/yaml_private.h
+++ b/ext/psych/yaml/yaml_private.h
@@ -146,9 +146,12 @@ yaml_string_join(
      (string).start = (string).pointer = (string).end = 0)
 
 #define STRING_EXTEND(context,string)                                           \
-    (((string).pointer+5 < (string).end)                                        \
+    ((((string).pointer+5 < (string).end)                                       \
         || yaml_string_extend(&(string).start,                                  \
-            &(string).pointer, &(string).end))
+            &(string).pointer, &(string).end)) ?                                \
+         1 :                                                                    \
+        ((context)->error = YAML_MEMORY_ERROR,                                  \
+         0))
 
 #define CLEAR(context,string)                                                   \
     ((string).pointer = (string).start,                                         \


### PR DESCRIPTION
libyaml <= 0.1.5 is vulnerable to CVE-2014-2525. I created patch for libyaml-0.1.6 fixes.
- http://www.ocert.org/advisories/ocert-2014-003.html
- http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-2525
