### PR TITLE
Fix error in @dispatch_cache default value

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -71,7 +71,7 @@ module Psych
 
           method = respond_to?(method) ? method : h[klass.superclass]
 
-          raise(TypeError, "Can't dump #{target.class}") unless method
+          raise(TypeError, "can't dump #{klass.name}") unless method
 
           h[klass] = method
         end


### PR DESCRIPTION
The exception in @dispatch_cache's default value has an error( `target` is not a thing; raises "undefined local variable or method `target' for... "). This fixes that. (Also, the other exceptions in this file have a lowercase "can't".)

What was really fun is trying to test this. That exception should _never ever ever_ be raised, unless Ruby does something crazy to force the accessor of `@dispatch_cache` to somehow return `nil`. The only way I could do it is with a crazy test:

``` diff
diff --git a/test/psych/visitors/test_yaml_tree.rb b/test/psych/visitors/test_yaml_tree.rb
index 40702bc..a0b031d 100644
--- a/test/psych/visitors/test_yaml_tree.rb
+++ b/test/psych/visitors/test_yaml_tree.rb
@@ -38,6 +38,24 @@ module Psych
         assert(Psych.dump(Object.new) !~ /Object/, yaml)
       end

+      class Klass
+        def name
+          ObjectSpace.each_object(Psych::Visitors::YAMLTree) { |yt|
+            yt.instance_variable_get("@dispatch_cache")["foo"] = nil
+          }.to_s
+        end
+
+        def superclass; "foo"; end
+      end
+
+      def test_not_a_class
+        not_a_class = Klass.new
+        bad = Struct.new("Bad", :class)
+        assert_raises(TypeError) do
+          Psych.dump(bad.new(not_a_class))
+        end
+      end
+
       def test_struct_const
         foo = Struct.new("Foo", :bar)
         assert_cycle foo.new('bar')
```

Which I'm sure you don't want to commit. So only the fix is in this PR.
