### PR TITLE
Fix loading objects with instance variables named "null"

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -512,7 +512,7 @@ module Psych
         ivars = find_ivars target
 
         ivars.each do |iv|
-          @emitter.scalar("#{iv.to_s.sub(/^@/, '')}", nil, nil, true, false, Nodes::Scalar::ANY)
+          @emitter.scalar("#{iv.to_s.sub(/^@/, ':')}", nil, nil, true, false, Nodes::Scalar::ANY)
           accept target.instance_variable_get(iv)
         end
       end

--- a/test/psych/test_object.rb
+++ b/test/psych/test_object.rb
@@ -19,6 +19,14 @@ module Psych
     end
   end
 
+  class WithNull
+    attr_accessor :null
+
+    def initialize
+      @null = true
+    end
+  end
+
   class TestObject < TestCase
     def test_dump_with_tag
       tag = Tagged.new
@@ -39,6 +47,13 @@ module Psych
 
       assert_instance_of(Foo, loaded)
       assert_equal loaded, loaded.parent
+    end
+
+    def test_null_named_ivar
+      original = WithNull.new
+      loaded = Psych.load(Psych.dump(original))
+
+      assert_equal(original.null, loaded.null)
     end
   end
 end


### PR DESCRIPTION
Do so by always interpreting mapping keys in an object as symbols rather than strings. When interpreted as a string it becomes `nil` which is then coerced to a string (`""`) and then tries to set the ivar `"@"` rather than `"@null"` raising the following error:

> NameError: `@' is not allowed as an instance variable name
