### PR TITLE
Add ability to substitute objects during encoding and decoding

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -388,7 +388,8 @@ module Psych
   #
   # Dump Ruby object +o+ to a YAML string.  Optional +options+ may be passed in
   # to control the output format.  If an IO object is passed in, the YAML will
-  # be dumped to that IO object.
+  # be dumped to that IO object. If a block is provided, it will be passed each
+  # object before it's encoded; the block can return a substitute object in its place.
   #
   # Example:
   #
@@ -403,25 +404,27 @@ module Psych
   #
   #   # Dump an array to an IO with indentation set
   #   Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
-  def self.dump o, io = nil, options = {}
+  def self.dump o, io = nil, options = {}, &substitute_block
     if Hash === io
       options = io
       io      = nil
     end
 
-    visitor = Psych::Visitors::YAMLTree.create options
+    visitor = Psych::Visitors::YAMLTree.create(options, &substitute_block)
     visitor << o
     visitor.tree.yaml io, options
   end
 
   ###
-  # Dump a list of objects as separate documents to a document stream.
+  # Dump a list of objects as separate documents to a document stream. If a 
+  # block is provided, it will be passed each object before it's encoded; the 
+  # block can return a substitute object in its place.
   #
   # Example:
   #
   #   Psych.dump_stream("foo\n  ", {}) # => "--- ! \"foo\\n  \"\n--- {}\n"
-  def self.dump_stream *objects
-    visitor = Psych::Visitors::YAMLTree.create({})
+  def self.dump_stream *objects, &substitute_block
+    visitor = Psych::Visitors::YAMLTree.create({}, &substitute_block)
     objects.each do |o|
       visitor << o
     end

--- a/lib/psych/core_ext.rb
+++ b/lib/psych/core_ext.rb
@@ -9,9 +9,9 @@ class Object
   # call-seq: to_yaml(options = {})
   #
   # Convert an object to YAML.  See Psych.dump for more information on the
-  # available +options+.
-  def psych_to_yaml options = {}
-    Psych.dump self, options
+  # available +options+ and the substitute block.
+  def psych_to_yaml options = {}, &substitute_block
+    Psych.dump self, options, &substitute_block
   end
   remove_method :to_yaml rescue nil
   alias :to_yaml :psych_to_yaml

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -30,11 +30,12 @@ module Psych
       end
 
       ###
-      # Convert this node to Ruby.
+      # Convert this node to Ruby.  If a block is provided, it will be called 
+      # with each object as it is created; it may return a substitute object.
       #
       # See also Psych::Visitors::ToRuby
-      def to_ruby
-        Visitors::ToRuby.create.accept(self)
+      def to_ruby(&substitute_block)
+        Visitors::ToRuby.create(&substitute_block).accept(self)
       end
       alias :transform :to_ruby
 

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -137,10 +137,10 @@ module Psych
             instance.init_with coder
           end
 
-          return instance
+          return substitute instance
         end
 
-        case o.tag
+        substitute case o.tag
         when nil
           register_empty(o)
         when '!omap', 'tag:yaml.org,2002:omap'
@@ -284,7 +284,7 @@ module Psych
       end
 
       def visit_Psych_Nodes_Stream o
-        o.children.map { |c| accept c }
+        substitute o.children.map { |c| accept c }
       end
 
       def visit_Psych_Nodes_Alias o

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -161,11 +161,11 @@ module Psych
 
       def visit_Psych_Nodes_Mapping o
         if Psych.load_tags[o.tag]
-          return revive(resolve_class(Psych.load_tags[o.tag]), o)
+          return substitute revive(resolve_class(Psych.load_tags[o.tag]), o)
         end
-        return revive_hash(register(o, {}), o) unless o.tag
+        return substitute revive_hash(register(o, {}), o) unless o.tag
 
-        case o.tag
+        substitute case o.tag
         when /^!ruby\/struct:?(.*)?$/
           klass = resolve_class($1) if $1
 

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1291,15 +1291,20 @@ EOY
       yaml = <<EOY
   one: foo
   two: bar
-  three: baz
+  three: 
+    - a
+    - b
+    - c
 EOY
-      specimen = { 'ONE' => 'FOO', 'THREE' => 'BAZ', 'TWO' => 'BAR', 'natural_size' => 3 }
+      specimen = { 'ONE' => 'FOO', 'THREE' => ['A', 'B', 'C', 'C', 'B', 'A'], 'TWO' => 'BAR', 'natural_size' => 3 }
       result = Psych.load(yaml) do |obj|
         case obj
         when String
           obj.upcase
         when Hash
           obj.merge({ 'natural_size' => obj.size })
+        when Array
+          obj + obj.reverse
         else
           obj
         end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1311,4 +1311,31 @@ EOY
       end
       assert_equal(specimen, result)
   	end
+
+  	def test_dump_substitutions
+  		# Based on test_simple_map
+      specimen = <<EOY
+---
+one: foo
+three:
+- a
+- b
+- c
+two: bar
+EOY
+      input = { 'ONE' => 'FOO', 'THREE' => ['A', 'B', 'C', 'C', 'B', 'A'], 'TWO' => 'BAR', 'natural_size' => 3 }
+      result = Psych.dump(input) do |obj|
+        case obj
+        when String
+          obj.downcase
+        when Hash
+          obj.delete_if { |k, v| k == 'natural_size' }
+        when Array
+          obj.uniq
+        else
+          obj
+        end
+      end
+      assert_equal(specimen, result)
+  	end
 end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1293,10 +1293,13 @@ EOY
   two: bar
   three: baz
 EOY
-      specimen = { 'ONE' => 'FOO', 'THREE' => 'BAZ', 'TWO' => 'BAR' }
+      specimen = { 'ONE' => 'FOO', 'THREE' => 'BAZ', 'TWO' => 'BAR', 'natural_size' => 3 }
       result = Psych.load(yaml) do |obj|
-        if obj.is_a?(String) 
+        case obj
+        when String
           obj.upcase
+        when Hash
+          obj.merge({ 'natural_size' => obj.size })
         else
           obj
         end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1285,4 +1285,22 @@ EOY
       yaml = Psych.dump '*foo'
       refute_match '!', yaml
     end
+    
+  	def test_load_substitutions
+  		# Based on test_simple_map
+      yaml = <<EOY
+  one: foo
+  two: bar
+  three: baz
+EOY
+      specimen = { 'ONE' => 'FOO', 'THREE' => 'BAZ', 'TWO' => 'BAR' }
+      result = Psych.load(yaml) do |obj|
+        if obj.is_a?(String) 
+          obj.upcase
+        else
+          obj
+        end
+      end
+      assert_equal(result, specimen)
+  	end
 end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1288,7 +1288,7 @@ EOY
     
   	def test_load_substitutions
   		# Based on test_simple_map
-      yaml = <<EOY
+      input = <<EOY
   one: foo
   two: bar
   three: 
@@ -1297,7 +1297,7 @@ EOY
     - c
 EOY
       specimen = { 'ONE' => 'FOO', 'THREE' => ['A', 'B', 'C', 'C', 'B', 'A'], 'TWO' => 'BAR', 'natural_size' => 3 }
-      result = Psych.load(yaml) do |obj|
+      result = Psych.load(input) do |obj|
         case obj
         when String
           obj.upcase
@@ -1309,6 +1309,6 @@ EOY
           obj
         end
       end
-      assert_equal(result, specimen)
+      assert_equal(specimen, result)
   	end
 end


### PR DESCRIPTION
This pull request includes changes that allow users to alter the objects being encoded or decoded by Psych. My own app will use this capability to replace ActiveRecord objects with placeholders that fetch the current version of the object rather than re-creating the old version, but you can probably imagine many other uses for it.

In this version of the pull request, you use this feature by giving a block to calls like `YAML.load` or `YAML.dump`. Each time an object is about to be encoded, or has just been decoded, it is passed to the block. If the block returns a different object than the original, it will be used in the original object's place.

I'm not sure if this is the right interface for this feature—it's probably not something that would be needed often, after all, and you may want to leave the block open for some other use. I'm open to suggestions on other ways to implement this.

This is also my first Psych patch. I've added tests and updated the documentation to explain this feature, but I may have missed other things I should have done. All tests pass on my machine.
