### PR TITLE
GC can break an ongoing serialization

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -16,10 +16,12 @@ module Psych
         def initialize
           @obj_to_id   = {}
           @obj_to_node = {}
+          @targets     = []
           @counter     = 0
         end
 
         def register target, node
+          @targets << target
           @obj_to_node[target.object_id] = node
         end
 


### PR DESCRIPTION
The YAML serializer makes use of `object_id` to determine whether a `target` object has already been encountered and allow use of an anchor rather than inlining the whole object again.  However, this breaks down if GC has collected the original `target` during the course of serialization (as `object_id` is only unique for active objects).

This patch retains a reference to the `target` so GC can't sweep it away.

(I did consider doing something with `Object#hash` in order to try and keep the memory footprint low, but I don't think that's a sane approach as multiple objects can have the same `hash` etc...)
