### PR TITLE
Allow dumping of Delegator subclasses

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -271,6 +271,21 @@ module Psych
           end
           map
 
+        when /^!ruby\/marshalable:(.*)$/
+          name = $1
+          klass = resolve_class(name)
+          obj = register(o, klass.allocate)
+
+          if obj.respond_to?(:init_with)
+            init_with(obj, revive_hash({}, o), o)
+          elsif obj.respond_to?(:marshal_load)
+            marshal_data = o.children.map(&method(:accept))
+            obj.marshal_load(marshal_data)
+            obj
+          else
+            raise ArgumentError, "Cannot deserialize #{name}"
+          end
+
         else
           revive_hash(register(o, {}), o)
         end

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -27,6 +27,8 @@ module Psych
 
         def key? target
           @obj_to_node.key? target.object_id
+        rescue NoMethodError
+          false
         end
 
         def id_for target
@@ -409,6 +411,18 @@ module Psych
         else
           @emitter.scalar ":#{o}", nil, nil, true, false, Nodes::Scalar::ANY
         end
+      end
+
+      def visit_BasicObject o
+        tag = Psych.dump_tags[o.class]
+        tag ||= "!ruby/marshalable:#{o.class.name}"
+
+        map = @emitter.start_mapping(nil, tag, false, Nodes::Mapping::BLOCK)
+        register(o, map)
+
+        o.marshal_dump.each(&method(:accept))
+
+        @emitter.end_mapping
       end
 
       private

--- a/test/psych/test_marshalable.rb
+++ b/test/psych/test_marshalable.rb
@@ -1,0 +1,54 @@
+require_relative 'helper'
+require 'delegate'
+
+module Psych
+  class TestMarshalable < TestCase
+    def test_objects_defining_marshal_dump_and_marshal_load_can_be_dumped
+      sd = SimpleDelegator.new(1)
+      loaded = Psych.load(Psych.dump(sd))
+
+      assert_instance_of(SimpleDelegator, loaded)
+      assert_equal(sd, loaded)
+    end
+
+    class PsychCustomMarshalable < BasicObject
+      attr_reader :foo
+
+      def initialize(foo)
+        @foo = foo
+      end
+
+      def marshal_dump
+        [foo]
+      end
+
+      def mashal_load(data)
+        @foo = data[0]
+      end
+
+      def init_with(coder)
+        @foo = coder['foo']
+      end
+
+      def encode_with(coder)
+        coder['foo'] = 2
+      end
+
+      def respond_to?(method)
+        [:marshal_dump, :marshal_load, :init_with, :encode_with].include?(method)
+      end
+
+      def class
+        PsychCustomMarshalable
+      end
+    end
+
+    def test_init_with_takes_priority_over_marshal_methods
+      obj = PsychCustomMarshalable.new(1)
+      loaded = Psych.load(Psych.dump(obj))
+
+      assert(PsychCustomMarshalable === loaded)
+      assert_equal(2, loaded.foo)
+    end
+  end
+end


### PR DESCRIPTION
These objects can be mostly treated the same as objects, with the caveat
that the object being delegated to needs to be set through `__setobj__`,
rather than whatever instance variable it was stored as.

Fixes #100 
