### PR TITLE
fixed build error caused by trunk changes

### DIFF
--- a/ext/psych/psych_emitter.c
+++ b/ext/psych/psych_emitter.c
@@ -42,7 +42,9 @@ static const rb_data_type_t psych_emitter_type = {
     "Psych/emitter",
     {0, dealloc, 0,},
     0, 0,
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY,
+#endif
 };
 
 static VALUE allocate(VALUE klass)

--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -62,7 +62,9 @@ static const rb_data_type_t psych_parser_type = {
     "Psych/parser",
     {0, dealloc, 0,},
     0, 0,
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     RUBY_TYPED_FREE_IMMEDIATELY,
+#endif
 };
 
 static VALUE allocate(VALUE klass)


### PR DESCRIPTION
@tenderlove 

RUBY_TYPED_FREE_IMMEDIATELY is only provided on Ruby 2.2.0.
