### PR TITLE
Unify Psych version constants to psych/versions.rb.

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: false
+require 'psych/versions'
 case RUBY_ENGINE
 when 'jruby'
   require 'psych_jars'
@@ -223,9 +224,6 @@ require 'psych/class_loader'
 #   # => "a"
 
 module Psych
-  # The version is Psych you're using
-  VERSION         = '2.2.1'
-
   # The version of libyaml Psych is using
   LIBYAML_VERSION = Psych.libyaml_version.join '.'
 

--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: false
 module Psych
-  DEFAULT_SNAKEYAML_VERSION = '1.17'.freeze
+  # The version is Psych you're using
+  VERSION = '2.2.1'
+
+  if RUBY_ENGINE == 'jruby'
+    DEFAULT_SNAKEYAML_VERSION = '1.17'.freeze
+  end
 end

--- a/lib/psych_jars.rb
+++ b/lib/psych_jars.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: false
-require 'psych/versions'
 require 'psych.jar'
 
 require 'jar-dependencies'

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require 'psych/versions'
+require_relative 'lib/psych/versions'
 
 Gem::Specification.new do |s|
   s.name = "psych"

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
+require 'psych/versions'
 
 Gem::Specification.new do |s|
   s.name = "psych"
-  s.version = "2.2.1"
+  s.version = Psych::VERSION
   s.authors = ["Aaron Patterson", "SHIBATA Hiroshi", "Charles Oliver Nutter"]
   s.email = ["aaron@tenderlovemaking.com", "hsbt@ruby-lang.org", "headius@headius.com"]
   s.date = "2016-11-14"
@@ -30,9 +31,8 @@ DESCRIPTION
   s.add_development_dependency 'minitest', "~> 5.0"
 
   if RUBY_PLATFORM =~ /java/
-    require 'psych/versions'
     s.platform = 'java'
-    s.requirements = "jar org.yaml:snakeyaml, 1.17"
+    s.requirements = "jar org.yaml:snakeyaml, #{Psych::DEFAULT_SNAKEYAML_VERSION}"
     s.add_dependency 'jar-dependencies', '>= 0.1.7'
     s.add_development_dependency 'ruby-maven'
   else


### PR DESCRIPTION
I unified version constants in psych. and revert 146a637e2205b2b36a6fa83fc0c6f7ce0c74e123 in psych.gemspec

@headius Can you try to `rake compile` with JRuby 9k? I think rake can references `Psych::DEFAULT_SNAKEYAML_VERSION` in psych.gemspec

ref. https://github.com/ruby/psych/issues/297