### PR TITLE
Removed HAVE_RUBY_ENCODING_H

### DIFF
--- a/ext/psych/psych.h
+++ b/ext/psych/psych.h
@@ -2,10 +2,7 @@
 #define PSYCH_H
 
 #include <ruby.h>
-
-#ifdef HAVE_RUBY_ENCODING_H
 #include <ruby/encoding.h>
-#endif
 
 #include <yaml.h>
 

--- a/ext/psych/psych_emitter.c
+++ b/ext/psych/psych_emitter.c
@@ -23,11 +23,7 @@ static void emit(yaml_emitter_t * emitter, yaml_event_t * event)
 static int writer(void *ctx, unsigned char *buffer, size_t size)
 {
     VALUE self = (VALUE)ctx, io = rb_attr_get(self, id_io);
-#ifdef HAVE_RUBY_ENCODING_H
     VALUE str = rb_enc_str_new((const char *)buffer, (long)size, rb_utf8_encoding());
-#else
-    VALUE str = rb_str_new((const char *)buffer, (long)size);
-#endif
     VALUE wrote = rb_funcall(io, id_write, 1, str);
     return (int)NUM2INT(wrote);
 }
@@ -170,9 +166,7 @@ static VALUE start_document(VALUE self, VALUE version, VALUE tags, VALUE imp)
     if(RTEST(tags)) {
 	long i = 0;
 	long len;
-#ifdef HAVE_RUBY_ENCODING_H
 	rb_encoding * encoding = rb_utf8_encoding();
-#endif
 
 	Check_Type(tags, T_ARRAY);
 
@@ -195,10 +189,8 @@ static VALUE start_document(VALUE self, VALUE version, VALUE tags, VALUE imp)
 	    value = RARRAY_AREF(tuple, 1);
 	    StringValue(name);
 	    StringValue(value);
-#ifdef HAVE_RUBY_ENCODING_H
 	    name = rb_str_export_to_enc(name, encoding);
 	    value = rb_str_export_to_enc(value, encoding);
-#endif
 
 	    tail->handle = (yaml_char_t *)RSTRING_PTR(name);
 	    tail->prefix = (yaml_char_t *)RSTRING_PTR(value);
@@ -259,14 +251,11 @@ static VALUE scalar(
 	) {
     yaml_emitter_t * emitter;
     yaml_event_t event;
-#ifdef HAVE_RUBY_ENCODING_H
     rb_encoding *encoding;
-#endif
     TypedData_Get_Struct(self, yaml_emitter_t, &psych_emitter_type, emitter);
 
     Check_Type(value, T_STRING);
 
-#ifdef HAVE_RUBY_ENCODING_H
     encoding = rb_utf8_encoding();
 
     value = rb_str_export_to_enc(value, encoding);
@@ -280,7 +269,6 @@ static VALUE scalar(
 	Check_Type(tag, T_STRING);
 	tag = rb_str_export_to_enc(tag, encoding);
     }
-#endif
 
     yaml_scalar_event_initialize(
 	    &event,
@@ -315,7 +303,6 @@ static VALUE start_sequence(
     yaml_emitter_t * emitter;
     yaml_event_t event;
 
-#ifdef HAVE_RUBY_ENCODING_H
     rb_encoding * encoding = rb_utf8_encoding();
 
     if(!NIL_P(anchor)) {
@@ -327,7 +314,6 @@ static VALUE start_sequence(
 	Check_Type(tag, T_STRING);
 	tag = rb_str_export_to_enc(tag, encoding);
     }
-#endif
 
     TypedData_Get_Struct(self, yaml_emitter_t, &psych_emitter_type, emitter);
 
@@ -379,12 +365,10 @@ static VALUE start_mapping(
 	) {
     yaml_emitter_t * emitter;
     yaml_event_t event;
-#ifdef HAVE_RUBY_ENCODING_H
     rb_encoding *encoding;
-#endif
+
     TypedData_Get_Struct(self, yaml_emitter_t, &psych_emitter_type, emitter);
 
-#ifdef HAVE_RUBY_ENCODING_H
     encoding = rb_utf8_encoding();
 
     if(!NIL_P(anchor)) {
@@ -396,7 +380,6 @@ static VALUE start_mapping(
 	Check_Type(tag, T_STRING);
 	tag = rb_str_export_to_enc(tag, encoding);
     }
-#endif
 
     yaml_mapping_start_event_initialize(
 	    &event,
@@ -442,12 +425,10 @@ static VALUE alias(VALUE self, VALUE anchor)
     yaml_event_t event;
     TypedData_Get_Struct(self, yaml_emitter_t, &psych_emitter_type, emitter);
 
-#ifdef HAVE_RUBY_ENCODING_H
     if(!NIL_P(anchor)) {
 	Check_Type(anchor, T_STRING);
 	anchor = rb_str_export_to_enc(anchor, rb_utf8_encoding());
     }
-#endif
 
     yaml_alias_event_initialize(
 	    &event,

--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -93,7 +93,6 @@ static VALUE make_exception(yaml_parser_t * parser, VALUE path)
 	    parser->context ? rb_usascii_str_new2(parser->context) : Qnil);
 }
 
-#ifdef HAVE_RUBY_ENCODING_H
 static VALUE transcode_string(VALUE src, int * parser_encoding)
 {
     int utf8    = rb_utf8_encindex();
@@ -170,8 +169,6 @@ static VALUE transcode_io(VALUE src, int * parser_encoding)
 
     return src;
 }
-
-#endif
 
 static VALUE protected_start_stream(VALUE pointer)
 {
@@ -253,10 +250,8 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
     int tainted = 0;
     int state = 0;
     int parser_encoding = YAML_ANY_ENCODING;
-#ifdef HAVE_RUBY_ENCODING_H
     int encoding = rb_utf8_encindex();
     rb_encoding * internal_enc = rb_default_internal_encoding();
-#endif
     VALUE handler = rb_iv_get(self, "@handler");
 
     if (rb_scan_args(argc, argv, "11", &yaml, &path) == 1) {
@@ -274,18 +269,14 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
     if (OBJ_TAINTED(yaml)) tainted = 1;
 
     if (rb_respond_to(yaml, id_read)) {
-#ifdef HAVE_RUBY_ENCODING_H
 	yaml = transcode_io(yaml, &parser_encoding);
 	yaml_parser_set_encoding(parser, parser_encoding);
-#endif
 	yaml_parser_set_input(parser, io_reader, (void *)yaml);
 	if (RTEST(rb_obj_is_kind_of(yaml, rb_cIO))) tainted = 1;
     } else {
 	StringValue(yaml);
-#ifdef HAVE_RUBY_ENCODING_H
 	yaml = transcode_string(yaml, &parser_encoding);
 	yaml_parser_set_encoding(parser, parser_encoding);
-#endif
 	yaml_parser_set_input_string(
 		parser,
 		(const unsigned char *)RSTRING_PTR(yaml),
@@ -338,17 +329,13 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
 			if(start->handle) {
 			    handle = rb_str_new2((const char *)start->handle);
 			    if (tainted) OBJ_TAINT(handle);
-#ifdef HAVE_RUBY_ENCODING_H
 			    PSYCH_TRANSCODE(handle, encoding, internal_enc);
-#endif
 			}
 
 			if(start->prefix) {
 			    prefix = rb_str_new2((const char *)start->prefix);
 			    if (tainted) OBJ_TAINT(prefix);
-#ifdef HAVE_RUBY_ENCODING_H
 			    PSYCH_TRANSCODE(prefix, encoding, internal_enc);
-#endif
 			}
 
 			rb_ary_push(tag_directives, rb_ary_new3((long)2, handle, prefix));
@@ -377,9 +364,7 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
 		if(event.data.alias.anchor) {
 		    alias = rb_str_new2((const char *)event.data.alias.anchor);
 		    if (tainted) OBJ_TAINT(alias);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(alias, encoding, internal_enc);
-#endif
 		}
 
 		args[0] = handler;
@@ -399,24 +384,18 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
 		    );
 		if (tainted) OBJ_TAINT(val);
 
-#ifdef HAVE_RUBY_ENCODING_H
 		PSYCH_TRANSCODE(val, encoding, internal_enc);
-#endif
 
 		if(event.data.scalar.anchor) {
 		    anchor = rb_str_new2((const char *)event.data.scalar.anchor);
 		    if (tainted) OBJ_TAINT(anchor);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(anchor, encoding, internal_enc);
-#endif
 		}
 
 		if(event.data.scalar.tag) {
 		    tag = rb_str_new2((const char *)event.data.scalar.tag);
 		    if (tainted) OBJ_TAINT(tag);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(tag, encoding, internal_enc);
-#endif
 		}
 
 		plain_implicit =
@@ -446,18 +425,14 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
 		if(event.data.sequence_start.anchor) {
 		    anchor = rb_str_new2((const char *)event.data.sequence_start.anchor);
 		    if (tainted) OBJ_TAINT(anchor);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(anchor, encoding, internal_enc);
-#endif
 		}
 
 		tag = Qnil;
 		if(event.data.sequence_start.tag) {
 		    tag = rb_str_new2((const char *)event.data.sequence_start.tag);
 		    if (tainted) OBJ_TAINT(tag);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(tag, encoding, internal_enc);
-#endif
 		}
 
 		implicit =
@@ -486,17 +461,13 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
 		if(event.data.mapping_start.anchor) {
 		    anchor = rb_str_new2((const char *)event.data.mapping_start.anchor);
 		    if (tainted) OBJ_TAINT(anchor);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(anchor, encoding, internal_enc);
-#endif
 		}
 
 		if(event.data.mapping_start.tag) {
 		    tag = rb_str_new2((const char *)event.data.mapping_start.tag);
 		    if (tainted) OBJ_TAINT(tag);
-#ifdef HAVE_RUBY_ENCODING_H
 		    PSYCH_TRANSCODE(tag, encoding, internal_enc);
-#endif
 		}
 
 		implicit =

--- a/ext/psych/psych_to_ruby.c
+++ b/ext/psych/psych_to_ruby.c
@@ -21,11 +21,7 @@ static VALUE build_exception(VALUE self, VALUE klass, VALUE mesg)
  */
 static VALUE path2class(VALUE self, VALUE path)
 {
-#ifdef HAVE_RUBY_ENCODING_H
     return rb_path_to_class(path);
-#else
-    return rb_path2class(StringValuePtr(path));
-#endif
 }
 
 void Init_psych_to_ruby(void)


### PR DESCRIPTION
After Ruby 1.9.x, Ruby always have `HAVE_RUBY_ENCODING_H`. We should remove it.