### PR TITLE
Remove deprecated code related syck

### DIFF
--- a/lib/psych/core_ext.rb
+++ b/lib/psych/core_ext.rb
@@ -4,18 +4,14 @@ class Object
     Psych.add_tag(url, self)
   end
 
-  # FIXME: rename this to "to_yaml" when syck is removed
-
   ###
   # call-seq: to_yaml(options = {})
   #
   # Convert an object to YAML.  See Psych.dump for more information on the
   # available +options+.
-  def psych_to_yaml options = {}
+  def to_yaml options = {}
     Psych.dump self, options
   end
-  remove_method :to_yaml rescue nil
-  alias :to_yaml :psych_to_yaml
 end
 
 class Module

--- a/lib/psych/core_ext.rb
+++ b/lib/psych/core_ext.rb
@@ -15,16 +15,13 @@ class Object
 end
 
 class Module
-  def psych_yaml_as url
+  def yaml_as url
     return if caller[0].end_with?('rubytypes.rb')
     if $VERBOSE
       warn "#{caller[0]}: yaml_as is deprecated, please use yaml_tag"
     end
     Psych.add_tag(url, self)
   end
-
-  remove_method :yaml_as rescue nil
-  alias :yaml_as :psych_yaml_as
 end
 
 if defined?(::IRB)

--- a/lib/psych/deprecated.rb
+++ b/lib/psych/deprecated.rb
@@ -9,19 +9,6 @@ module Psych
     attr_accessor :to_yaml_style
   end
 
-  def self.quick_emit thing, opts = {}, &block # :nodoc:
-    warn "#{caller[0]}: YAML.quick_emit is deprecated" if $VERBOSE && !caller[0].start_with?(File.dirname(__FILE__))
-    target = eval 'self', block.binding
-    target.extend DeprecatedMethods
-    metaclass = class << target; self; end
-    metaclass.send(:define_method, :encode_with) do |coder|
-      target.taguri        = coder.tag
-      target.to_yaml_style = coder.style
-      block.call coder
-    end
-    target.psych_to_yaml unless opts[:nodump]
-  end
-
   # This method is deprecated, use Psych.load_stream instead.
   def self.load_documents yaml, &block
     if $VERBOSE

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -142,7 +142,7 @@ module Psych
         if target.respond_to?(:to_yaml)
           begin
             loc = target.method(:to_yaml).source_location.first
-            if loc !~ /(syck\/rubytypes.rb|psych\/core_ext.rb)/
+            if loc !~ /psych\/core_ext.rb/
               unless target.respond_to?(:encode_with)
                 if $VERBOSE
                   warn "implementing to_yaml is deprecated, please implement \"encode_with\""

--- a/test/psych/helper.rb
+++ b/test/psych/helper.rb
@@ -50,10 +50,10 @@ module Psych
     def assert_to_yaml( obj, yaml )
       assert_equal( obj, Psych::load( yaml ) )
       assert_equal( obj, Psych::parse( yaml ).transform )
-      assert_equal( obj, Psych::load( obj.psych_to_yaml ) )
-      assert_equal( obj, Psych::parse( obj.psych_to_yaml ).transform )
+      assert_equal( obj, Psych::load( obj.to_yaml ) )
+      assert_equal( obj, Psych::parse( obj.to_yaml ).transform )
       assert_equal( obj, Psych::load(
-        obj.psych_to_yaml(
+        obj.to_yaml(
           :UseVersion => true, :UseHeader => true, :SortKeys => true
         )
       ))
@@ -73,11 +73,11 @@ module Psych
       if obj.nil?
         assert_nil Psych.load(v.tree.yaml)
         assert_nil Psych::load(Psych.dump(obj))
-        assert_nil Psych::load(obj.psych_to_yaml)
+        assert_nil Psych::load(obj.to_yaml)
       else
         assert_equal(obj, Psych.load(v.tree.yaml))
         assert_equal(obj, Psych::load(Psych.dump(obj)))
-        assert_equal(obj, Psych::load(obj.psych_to_yaml))
+        assert_equal(obj, Psych::load(obj.to_yaml))
       end
     end
 

--- a/test/psych/test_deprecated.rb
+++ b/test/psych/test_deprecated.rb
@@ -8,45 +8,10 @@ module Psych
       Psych.domain_types.clear
     end
 
-    class QuickEmitter
-      attr_reader :name
-      attr_reader :value
-
-      def initialize
-        @name  = 'hello!!'
-        @value = 'Friday!'
-      end
-
-      def to_yaml opts = {}
-        Psych.quick_emit object_id, opts do |out|
-          out.map taguri, to_yaml_style do |map|
-            map.add 'name', @name
-            map.add 'value', nil
-          end
-        end
-      end
-    end
+    class QuickEmitter; end
 
     def setup
-      @qe = QuickEmitter.new
       @orig_verbose, $VERBOSE = $VERBOSE, false
-    end
-
-    def test_quick_emit
-      qe2 = Psych.load @qe.to_yaml
-      assert_equal @qe.name, qe2.name
-      assert_instance_of QuickEmitter, qe2
-      assert_nil qe2.value
-    end
-
-    def test_recursive_quick_emit
-      hash  = { :qe => @qe }
-      hash2 = Psych.load Psych.dump hash
-      qe    = hash2[:qe]
-
-      assert_equal @qe.name, qe.name
-      assert_instance_of QuickEmitter, qe
-      assert_nil qe.value
     end
 
     class QuickEmitterEncodeWith

--- a/test/psych/test_deprecated.rb
+++ b/test/psych/test_deprecated.rb
@@ -114,7 +114,7 @@ module Psych
 
     class YamlAs
       TestCase.suppress_warning do
-        psych_yaml_as 'helloworld' # this should be yaml_as but to avoid syck
+        yaml_as 'helloworld'
       end
     end
 


### PR DESCRIPTION
I removed deprecated alias, name, method prefixes. Their are related with syck that old yaml serializer for ruby language. 

According to the syck was deprecate after Ruby 2.0 release. It's time to remove it when Ruby 2.4 released.