### PR TITLE
Update snakeyaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
 
 before_install: gem install bundler --no-document
 
+script: rake
+
 addons:
   apt:
     packages:

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ if RUBY_PLATFORM =~ /java/
     # and tell maven via system properties the snakeyaml version
     # this is basically the same as running from the commandline:
     # rmvn dependency:build-classpath -Dsnakeyaml.version='use version from Psych::DEFAULT_SNAKEYAML_VERSION here'
-    Maven::Ruby::Maven.new.exec('dependency:build-classpath', "-Dsnakeyaml.version=#{Psych::DEFAULT_SNAKEYAML_VERSION}", '-Dverbose=true')
+    Maven::Ruby::Maven.new.exec('dependency:build-classpath', "-Dsnakeyaml.version=1.17", '-Dverbose=true')
     ext.source_version = '1.7'
     ext.target_version = '1.7'
     ext.classpath = File.read('pkg/classpath')

--- a/ext/java/PsychParser.java
+++ b/ext/java/PsychParser.java
@@ -241,10 +241,9 @@ public class PsychParser extends RubyObject {
     private void handleDocumentStart(ThreadContext context, DocumentStartEvent dse, boolean tainted, IRubyObject handler) {
         Ruby runtime = context.runtime;
         DumperOptions.Version _version = dse.getVersion();
-        Integer[] versionInts = _version == null ? null : _version.getArray();
-        IRubyObject version = versionInts == null ?
+        IRubyObject version = _version == null ?
             RubyArray.newArray(runtime) :
-            RubyArray.newArray(runtime, runtime.newFixnum(versionInts[0]), runtime.newFixnum(versionInts[1]));
+            RubyArray.newArray(runtime, runtime.newFixnum(_version.major()), runtime.newFixnum(_version.minor()));
         
         Map<String, String> tagsMap = dse.getTags();
         RubyArray tags = RubyArray.newArray(runtime);

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -34,7 +34,7 @@ DESCRIPTION
   if RUBY_ENGINE == 'jruby'
     s.platform = 'java'
     s.files.concat ["ext/java/PsychEmitter.java", "ext/java/PsychLibrary.java", "ext/java/PsychParser.java", "ext/java/PsychToRuby.java", "ext/java/PsychYamlTree.java", "lib/psych_jars.rb", "lib/psych.jar"]
-    s.requirements = "jar org.yaml:snakeyaml, #{Psych::DEFAULT_SNAKEYAML_VERSION}"
+    s.requirements = "jar org.yaml:snakeyaml, 1.17"
     s.add_dependency 'jar-dependencies', '>= 0.1.7'
     s.add_development_dependency 'ruby-maven'
   else


### PR DESCRIPTION
This re-updates snakeyaml to 1.17. I originally made the change in 146a637e2205b2b36a6fa83fc0c6f7ce0c74e123 and @hsbt reverted the code part in f5455216532f33e2b32bb035d14d820d1d37906b. This broke psych on JRuby, since the code changes there were required for the update to snakeyaml. @hsbt said there was a build error he was trying to fix...if that occurs again I will look into it.

We need to get this out into a release ASAP since the currently-released psych for JRuby is broken, and we hoped to update to it for our next release to pick up other bug fixes.