### PR TITLE
Preserve time zone offset when deserializing times

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -143,7 +143,7 @@ module Psych
         offset += ((tz[1] || 0) * 60)
       end
 
-      klass.at((time - offset).to_i, us)
+      klass.new(yy, m, dd, hh, mm, ss+us/(1_000_000r), offset)
     end
   end
 end

--- a/test/psych/test_date_time.rb
+++ b/test/psych/test_date_time.rb
@@ -19,6 +19,14 @@ module Psych
       assert_cycle time
     end
 
+    def test_timezone_offset
+      times = [Time.new(2017, 4, 13, 12, 0, 0, "+09:00"),
+               Time.new(2017, 4, 13, 12, 0, 0, "-05:00")]
+      cycled = Psych::load(Psych.dump times)
+      assert_match(/12:00:00 \+0900/, cycled.first.to_s)
+      assert_match(/12:00:00 -0500/,  cycled.last.to_s)
+    end
+
     def test_new_datetime
       assert_cycle DateTime.new
     end
@@ -26,6 +34,14 @@ module Psych
     def test_datetime_non_utc
       dt = DateTime.new(2017, 4, 13, 12, 0, 0.5, "+09:00")
       assert_cycle dt
+    end
+
+    def test_datetime_timezone_offset
+      times = [DateTime.new(2017, 4, 13, 12, 0, 0, "+09:00"),
+               DateTime.new(2017, 4, 13, 12, 0, 0, "-05:00")]
+      cycled = Psych::load(Psych.dump times)
+      assert_match(/12:00:00\+09:00/, cycled.first.to_s)
+      assert_match(/12:00:00-05:00/,  cycled.last.to_s)
     end
 
     def test_invalid_date

--- a/test/psych/test_date_time.rb
+++ b/test/psych/test_date_time.rb
@@ -9,8 +9,23 @@ module Psych
       assert_cycle time
     end
 
+    def test_usec
+      time = Time.utc(2017, 4, 13, 12, 0, 0, 5)
+      assert_cycle time
+    end
+
+    def test_non_utc
+      time = Time.new(2017, 4, 13, 12, 0, 0.5, "+09:00")
+      assert_cycle time
+    end
+
     def test_new_datetime
       assert_cycle DateTime.new
+    end
+
+    def test_datetime_non_utc
+      dt = DateTime.new(2017, 4, 13, 12, 0, 0.5, "+09:00")
+      assert_cycle dt
     end
 
     def test_invalid_date


### PR DESCRIPTION
Times with specified time zone offset are converted to local time, currently. I consider this a bug, because information that is present in the YAML gets lost needlessly.

I think the upcoming major version release would be a good occasion to fix this.

Current behavior:

``` ruby
require "psych"

ENV["TZ"] = "EST"

time = Time.new(2017, 4, 13, 12, 0, 0, "+02:00")
yaml = Psych.dump(time)
restored = Psych::load yaml

restored == time  # => true, it's the same point in time

yaml      # => "--- 2017-04-13 12:00:00.000000000 +02:00\n...\n"
time      # => 2017-04-13 12:00:00 +0200
restored  # => 2017-04-13 05:00:00 -0500 (!)
```

New behavior:

``` ruby
# ...
yaml      # => "--- 2017-04-13 12:00:00.000000000 +02:00\n...\n"
time      # => 2017-04-13 12:00:00 +0200
restored  # => 2017-04-13 12:00:00 +0200
```

Note that I am not at all familiar with the `psych` codebase, so feel free to give feedback if something is missing.

_Update:_ The first commit adds "bonus" test cases that do not directly concern the proposed change, but seemed reasonable.

_Update:_ DateTime will change similarly (without need for special treatment; it seems to rely on Time). I amended the commits to include a test case that verifies this behavior.