### PR TITLE
Add Psych::Handler#event_location

### DIFF
--- a/ext/java/PsychParser.java
+++ b/ext/java/PsychParser.java
@@ -190,6 +190,12 @@ public class PsychParser extends RubyObject {
             while (true) {
                 event = parser.getEvent();
 
+                IRubyObject start_line = runtime.newFixnum(event.getStartMark().getLine());
+                IRubyObject start_column = runtime.newFixnum(event.getStartMark().getColumn());
+                IRubyObject end_line = runtime.newFixnum(event.getEndMark().getLine());
+                IRubyObject end_column = runtime.newFixnum(event.getEndMark().getColumn());
+                invoke(context, handler, "event_location", start_line, start_column, end_line, end_column);
+
                 // FIXME: Event should expose a getID, so it can be switched
                 if (event.is(ID.StreamStart)) {
                     invoke(context, handler, "start_stream", runtime.newFixnum(YAML_ANY_ENCODING.ordinal()));
@@ -277,6 +283,7 @@ public class PsychParser extends RubyObject {
         
     private void handleScalar(ThreadContext context, ScalarEvent se, boolean tainted, IRubyObject handler) {
         Ruby runtime = context.runtime;
+
         IRubyObject anchor = stringOrNilFor(runtime, se.getAnchor(), tainted);
         IRubyObject tag = stringOrNilFor(runtime, se.getTag(), tainted);
         IRubyObject plain_implicit = runtime.newBoolean(se.getImplicit().canOmitTagInPlainScalar());

--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -16,6 +16,7 @@ static ID id_start_sequence;
 static ID id_end_sequence;
 static ID id_start_mapping;
 static ID id_end_mapping;
+static ID id_event_location;
 
 #define PSYCH_TRANSCODE(_str, _yaml_enc, _internal_enc) \
   do { \
@@ -232,6 +233,12 @@ static VALUE protected_end_stream(VALUE handler)
     return rb_funcall(handler, id_end_stream, 0);
 }
 
+static VALUE protected_event_location(VALUE pointer)
+{
+    VALUE *args = (VALUE *)pointer;
+    return rb_funcall3(args[0], id_event_location, 4, args + 1);
+}
+
 /*
  * call-seq:
  *    parser.parse(yaml)
@@ -294,6 +301,21 @@ static VALUE parse(int argc, VALUE *argv, VALUE self)
 
 	    rb_exc_raise(exception);
 	}
+
+	VALUE event_args[5];
+	VALUE start_line, start_column, end_line, end_column;
+
+	start_line = INT2NUM((long)event.start_mark.line);
+	start_column = INT2NUM((long)event.start_mark.column);
+	end_line = INT2NUM((long)event.end_mark.line);
+	end_column = INT2NUM((long)event.end_mark.column);
+
+	event_args[0] = handler;
+	event_args[1] = start_line;
+	event_args[2] = start_column;
+	event_args[3] = end_line;
+	event_args[4] = end_column;
+	rb_protect(protected_event_location, (VALUE)event_args, &state);
 
 	switch(event.type) {
 	    case YAML_STREAM_START_EVENT:
@@ -551,18 +573,19 @@ void Init_psych_parser(void)
     rb_define_method(cPsychParser, "parse", parse, -1);
     rb_define_method(cPsychParser, "mark", mark, 0);
 
-    id_read           = rb_intern("read");
-    id_path           = rb_intern("path");
-    id_empty          = rb_intern("empty");
-    id_start_stream   = rb_intern("start_stream");
-    id_end_stream     = rb_intern("end_stream");
-    id_start_document = rb_intern("start_document");
-    id_end_document   = rb_intern("end_document");
-    id_alias          = rb_intern("alias");
-    id_scalar         = rb_intern("scalar");
-    id_start_sequence = rb_intern("start_sequence");
-    id_end_sequence   = rb_intern("end_sequence");
-    id_start_mapping  = rb_intern("start_mapping");
-    id_end_mapping    = rb_intern("end_mapping");
+    id_read            = rb_intern("read");
+    id_path            = rb_intern("path");
+    id_empty           = rb_intern("empty");
+    id_start_stream    = rb_intern("start_stream");
+    id_end_stream      = rb_intern("end_stream");
+    id_start_document  = rb_intern("start_document");
+    id_end_document    = rb_intern("end_document");
+    id_alias           = rb_intern("alias");
+    id_scalar          = rb_intern("scalar");
+    id_start_sequence  = rb_intern("start_sequence");
+    id_end_sequence    = rb_intern("end_sequence");
+    id_start_mapping   = rb_intern("start_mapping");
+    id_end_mapping     = rb_intern("end_mapping");
+    id_event_location  = rb_intern("event_location");
 }
 /* vim: set noet sws=4 sw=4: */

--- a/lib/psych/handler.rb
+++ b/lib/psych/handler.rb
@@ -242,6 +242,11 @@ module Psych
     end
 
     ###
+    # Called before each event with line/column information.
+    def event_location(start_line, start_column, end_line, end_column)
+    end
+
+    ###
     # Is this handler a streaming handler?
     def streaming?
       false

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -17,6 +17,18 @@ module Psych
       # An associated tag
       attr_reader :tag
 
+      # The line number where this node start
+      attr_accessor :start_line
+
+      # The column number where this node start
+      attr_accessor :start_column
+
+      # The line number where this node ends
+      attr_accessor :end_line
+
+      # The column number where this node ends
+      attr_accessor :end_column
+
       # Create a new Psych::Nodes::Node
       def initialize
         @children = []

--- a/lib/psych/tree_builder.rb
+++ b/lib/psych/tree_builder.rb
@@ -23,6 +23,18 @@ module Psych
       @stack = []
       @last  = nil
       @root  = nil
+
+      @start_line   = nil
+      @start_column = nil
+      @end_line     = nil
+      @end_column   = nil
+    end
+
+    def event_location(start_line, start_column, end_line, end_column)
+      @start_line   = start_line
+      @start_column = start_column
+      @end_line     = end_line
+      @end_column   = end_column
     end
 
     %w{
@@ -32,12 +44,15 @@ module Psych
       class_eval %{
         def start_#{node.downcase}(anchor, tag, implicit, style)
           n = Nodes::#{node}.new(anchor, tag, implicit, style)
+          set_start_location(n)
           @last.children << n
           push n
         end
 
         def end_#{node.downcase}
-          pop
+          n = pop
+          set_end_location(n)
+          n
         end
       }
     end
@@ -49,6 +64,7 @@ module Psych
     # See Psych::Handler#start_document
     def start_document version, tag_directives, implicit
       n = Nodes::Document.new version, tag_directives, implicit
+      set_start_location(n)
       @last.children << n
       push n
     end
@@ -60,26 +76,35 @@ module Psych
     # See Psych::Handler#start_document
     def end_document implicit_end = !streaming?
       @last.implicit_end = implicit_end
-      pop
+      n = pop
+      set_end_location(n)
+      n
     end
 
     def start_stream encoding
       @root = Nodes::Stream.new(encoding)
+      set_start_location(@root)
       push @root
     end
 
     def end_stream
-      pop
+      n = pop
+      set_end_location(n)
+      n
     end
 
     def scalar value, anchor, tag, plain, quoted, style
       s = Nodes::Scalar.new(value,anchor,tag,plain,quoted,style)
+      set_location(s)
       @last.children << s
       s
     end
 
     def alias anchor
-      @last.children << Nodes::Alias.new(anchor)
+      a = Nodes::Alias.new(anchor)
+      set_location(a)
+      @last.children << a
+      a
     end
 
     private
@@ -92,6 +117,21 @@ module Psych
       x = @stack.pop
       @last = @stack.last
       x
+    end
+
+    def set_location(node)
+      set_start_location(node)
+      set_end_location(node)
+    end
+
+    def set_start_location(node)
+      node.start_line   = @start_line
+      node.start_column = @start_column
+    end
+
+    def set_end_location(node)
+      node.end_line   = @end_line
+      node.end_column = @end_column
     end
   end
 end

--- a/test/psych/test_tree_builder.rb
+++ b/test/psych/test_tree_builder.rb
@@ -21,6 +21,7 @@ module Psych
 
     def test_stream
       assert_instance_of Nodes::Stream, @tree
+      assert_location 0, 0, 8, 0, @tree
     end
 
     def test_documents
@@ -31,6 +32,7 @@ module Psych
       assert_equal [1,1], doc.version
       assert_equal [], doc.tag_directives
       assert_equal false, doc.implicit
+      assert_location 0, 0, 8, 0, doc
     end
 
     def test_sequence
@@ -43,6 +45,7 @@ module Psych
       assert_nil seq.tag
       assert_equal true, seq.implicit
       assert_equal Nodes::Sequence::BLOCK, seq.style
+      assert_location 2, 0, 8, 0, seq
     end
 
     def test_scalar
@@ -58,6 +61,7 @@ module Psych
       assert_equal true, scalar.plain
       assert_equal false, scalar.quoted
       assert_equal Nodes::Scalar::PLAIN, scalar.style
+      assert_location 2, 2, 2, 5, scalar
     end
 
     def test_mapping
@@ -66,6 +70,7 @@ module Psych
       map = seq.children[1]
 
       assert_instance_of Nodes::Mapping, map
+      assert_location 3, 2, 6, 1, map
     end
 
     def test_alias
@@ -75,6 +80,15 @@ module Psych
       al  = seq.children[2]
       assert_instance_of Nodes::Alias, al
       assert_equal 'A', al.anchor
+      assert_location 7, 2, 7, 4, al
+    end
+
+    private
+    def assert_location(start_line, start_column, end_line, end_column, node)
+      assert_equal start_line, node.start_line
+      assert_equal start_column, node.start_column
+      assert_equal end_line, node.end_line
+      assert_equal end_column, node.end_column
     end
   end
 end


### PR DESCRIPTION
Fixes #197

This adds a new reported event to `Psych::Handler`: `event_location`. This reports precise start/end line/column information.

The line/column information provided by `Psych::Parser#mark` is not very useful because it points to the location **past** the event.

For example, when using `Psych::Parser#mark` we can observe this behavior:

```ruby
require "psych"

class MyHandler < Psych::Handler
  attr_accessor :parser

  def scalar(value, anchor, tag, plain, quoted, style)
    puts "-" * 10
    p value
    puts "line: #{@parser.mark.line}"
    puts "col:  #{@parser.mark.column}"
  end

  def streaming?
    true
  end
end

handler = MyHandler.new
parser = Psych::Parser.new(handler)
handler.parser = parser

source = <<~YAML
foo:
  barbaz: 1

qux: 2
YAML

parser.parse source
```

Output:

```text
----------
"foo"
line: 0
col:  4
----------
"barbaz"
line: 1
col:  9
----------
"1"
line: 3
col:  0
----------
"qux"
line: 3
col:  4
----------
"2"
line: 4
col:  0
```

As you can see, the line/column information is exactly **after** the scalar value. In most cases this is not very terrible regarding the line number: it's correct in "foo" and "barbaz". However you can see that for "1", the reported line number is 3 instead of 1. This is because the parser is positioned at "qux" after parsing the scalar, which is a couple of lines below.

`libyaml` provides [`start_mark` and `end_mark`](https://github.com/yaml/libyaml/blob/660242d6a418f0348c61057ed3052450527b3abf/include/yaml.h#L473-L476) as information of an event, and as far as I can see this is the only information not accessible by Psych.

I initially though about adding this info as an extra argument to `Psych::Handler#scalar`. However, this is not backwards compatible. So, we can add a `Psych::Handler#event_location` with a default empty implementation in `Psych::Handler`. If you upgrade the gem version it will still work (unless someone provided a `event_location` method in a custom handler, which is very unlikely).

Another alternative would be to introduce `Psych::Parser#start_mark` and `Psych::Parser#end_mark` though it's a bit difficult and it would maybe be strange because those are related to each event, not to the parser.

With this PR, we can now do this:

```ruby
gem "psych", "=3.0.0.beta3" # I had to use this locally to test it
require "psych"

class MyHandler < Psych::Handler
  attr_accessor :parser

  def event_location(start_line, start_column, end_line, end_column)
    @start_line   = start_line
    @start_column = start_column
    @end_line     = end_line
    @end_column   = end_column
  end

  def scalar(value, anchor, tag, plain, quoted, style)
    puts "-" * 10
    p value
    puts "start line: #{@start_line}"
    puts "start col:  #{@start_column}"
    puts "end line:   #{@end_line}"
    puts "end col:    #{@end_column}"
  end

  def streaming?
    true
  end
end

handler = MyHandler.new
parser = Psych::Parser.new(handler)
handler.parser = parser

source = <<~YAML
foo:
  barbaz: 1

qux: 2
YAML

parser.parse source
```

Output:

```text
----------
"foo"
start line: 0
start col:  0
end line:   0
end col:    3
----------
"barbaz"
start line: 1
start col:  2
end line:   1
end col:    8
----------
"1"
start line: 1
start col:  10
end line:   1
end col:    11
----------
"qux"
start line: 3
start col:  0
end line:   3
end col:    3
----------
"2"
start line: 3
start col:  5
end line:   3
end col:    6
```

As you can see, the information is now super precise and correct :-)

In `libyaml`, the `start_mark` and `end_mark` event info is also provided for other YAML events, like `start_mapping` and `start_sequence`, but this is always the same as the current `Psych::Parser#mark` value, so there's no point in providing it for other events in Psych. This is also why I decided to call it `scalar_location` and not simply `event_location`.

Of course, all of the API details can be discussed (name, other ways to make it backwards compatible), but I think this will be a valuable addition to Psych.