### PR TITLE
Make possible to set coder output style for arrays and scalars.

### DIFF
--- a/lib/psych/coder.rb
+++ b/lib/psych/coder.rb
@@ -66,6 +66,7 @@ module Psych
     # Emit a scalar with +value+
     def scalar= value
       @type   = :scalar
+      @style  = Psych::Nodes::Scalar::ANY if @style == Psych::Nodes::Mapping::BLOCK
       @scalar = value
     end
 

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -521,9 +521,9 @@ module Psych
       def emit_coder c, o
         case c.type
         when :scalar
-          @emitter.scalar c.scalar, nil, c.tag, c.tag.nil?, false, Nodes::Scalar::ANY
+          @emitter.scalar c.scalar, nil, c.tag, c.tag.nil?, false, c.style
         when :seq
-          @emitter.start_sequence nil, c.tag, c.tag.nil?, Nodes::Sequence::BLOCK
+          @emitter.start_sequence nil, c.tag, c.tag.nil?, c.style
           c.seq.each do |thing|
             accept thing
           end

--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -208,6 +208,7 @@ module Psych
       foo = Psych.dump([1,2,3])
       assert_equal foo, "---\n- 1\n- 2\n- 3\n"
     end
+
     class TestArrayFlow < Array
       def encode_with(coder)
         coder.style = Psych::Nodes::Mapping::FLOW
@@ -215,24 +216,29 @@ module Psych
         coder.seq = self
       end
     end
+
     def test_coder_style_array_flow
       foo = Psych.dump(TestArrayFlow.new([1,2,3]))
       assert_equal foo, "--- [1, 2, 3]\n"
     end
+
     def test_coder_style_scalar_default
       foo = Psych.dump('some scalar')
       assert_equal foo, "--- some scalar\n...\n"
     end
+
     class TestStringAny < String
       def encode_with(coder)
         coder.tag = nil
         coder.scalar = self
       end
     end
+
     def test_coder_style_scalar_explicit_default
       foo = Psych.dump(TestStringAny.new('some scalar'))
       assert_equal foo, "--- some scalar\n...\n"
     end
+
     class TestStringQuoted < String
       def encode_with(coder)
         coder.style = Psych::Nodes::Scalar::SINGLE_QUOTED
@@ -240,10 +246,12 @@ module Psych
         coder.scalar = self
       end
     end
+
     def test_coder_style_scalar_quoted
       foo = Psych.dump(TestStringQuoted.new('some scalar'))
       assert_equal foo, "--- ! 'some scalar'\n"
     end
+
     class TestStringFolded < String
       def encode_with(coder)
         coder.style = Psych::Nodes::Scalar::FOLDED
@@ -251,6 +259,7 @@ module Psych
         coder.scalar = self
       end
     end
+
     def test_coder_style_scalar_folded
       foo = Psych.dump(TestStringFolded.new('some scalar'))
       assert_equal foo, "--- ! >-\n  some scalar\n"

--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -203,5 +203,57 @@ module Psych
       assert_equal foo.b, bar.b
       assert_nil bar.c
     end
+
+    def test_coder_style_array_default
+      foo = Psych.dump([1,2,3])
+      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
+    end
+    class TestArrayFlow < Array
+      def encode_with(coder)
+        coder.style = Psych::Nodes::Mapping::FLOW
+        coder.tag = nil
+        coder.seq = self
+      end
+    end
+    def test_coder_style_array_flow
+      foo = Psych.dump(TestArrayFlow.new([1,2,3]))
+      assert_equal foo, "--- [1, 2, 3]\n"
+    end
+    def test_coder_style_scalar_default
+      foo = Psych.dump('some scalar')
+      assert_equal foo, "--- some scalar\n...\n"
+    end
+    class TestStringAny < String
+      def encode_with(coder)
+        coder.tag = nil
+        coder.scalar = self
+      end
+    end
+    def test_coder_style_scalar_explicit_default
+      foo = Psych.dump(TestStringAny.new('some scalar'))
+      assert_equal foo, "--- some scalar\n...\n"
+    end
+    class TestStringQuoted < String
+      def encode_with(coder)
+        coder.style = Psych::Nodes::Scalar::SINGLE_QUOTED
+        coder.tag = nil
+        coder.scalar = self
+      end
+    end
+    def test_coder_style_scalar_quoted
+      foo = Psych.dump(TestStringQuoted.new('some scalar'))
+      assert_equal foo, "--- ! 'some scalar'\n"
+    end
+    class TestStringFolded < String
+      def encode_with(coder)
+        coder.style = Psych::Nodes::Scalar::FOLDED
+        coder.tag = nil
+        coder.scalar = self
+      end
+    end
+    def test_coder_style_scalar_folded
+      foo = Psych.dump(TestStringFolded.new('some scalar'))
+      assert_equal foo, "--- ! >-\n  some scalar\n"
+    end
   end
 end


### PR DESCRIPTION
Make possible to set coder output style for arrays and scalars. Well originally I wanted arrays but while I was at it ...

See #281 for discussion.

Ok, I can try making pull request ... it will be my first but how hard can that be?