### PR TITLE
Double quote strings that contain single quotes only (retry)

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -311,7 +311,7 @@ module Psych
           style = Nodes::Scalar::DOUBLE_QUOTED
         elsif @line_width && o.length > @line_width
           style = Nodes::Scalar::FOLDED
-        elsif o.match?(/^[^[:word:]][^"]*$/)
+        elsif o.match?(/^[^[:word:]][^"]*$/) || o.match?(/^([^"]*'+[^"]*)+$/)
           style = Nodes::Scalar::DOUBLE_QUOTED
         elsif not String === @ss.tokenize(o) or /\A0[0-7]*[89]/.match?(o)
           style = Nodes::Scalar::SINGLE_QUOTED

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -60,6 +60,13 @@ module Psych
       RUBY
     end
 
+    def test_doublequotes_when_there_are_single_quotes_only
+      str = "psych: Please don't escape ' with ' here."
+      yaml = Psych.dump str
+      assert_equal "--- \"psych: Please don't escape ' with ' here.\"\n", yaml
+      assert_equal str, Psych.load(yaml)
+    end
+
     def test_plain_when_shorten_than_line_width_and_no_final_line_break
       str = "Lorem ipsum"
       yaml = Psych.dump str, line_width: 12


### PR DESCRIPTION
Original pull request: https://github.com/ruby/psych/pull/325

@knugie Your changes was different behavior with bundler behavior: https://github.com/bundler/bundler/blob/master/lib/bundler/yaml_serializer.rb#L8

There is no time to coordinate this specification for Ruby 2.5.0. I try to this next year(Ruby 2.6 and psych 3.1.0)