### PR TITLE
Add :symbolize_names option to .safe_load too

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -300,7 +300,7 @@ module Psych
   #
   # A Psych::BadAlias exception will be raised if the yaml contains aliases
   # but the +aliases+ parameter is set to false.
-  def self.safe_load yaml, whitelist_classes = [], whitelist_symbols = [], aliases = false, filename = nil
+  def self.safe_load yaml, whitelist_classes = [], whitelist_symbols = [], aliases = false, filename = nil, symbolize_names: false
     result = parse(yaml, filename)
     return unless result
 
@@ -312,7 +312,9 @@ module Psych
     else
       visitor = Visitors::NoAliasRuby.new scanner, class_loader
     end
-    visitor.accept result
+    result = visitor.accept result
+    symbolize_names!(result) if symbolize_names
+    result
   end
 
   ###

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -184,20 +184,20 @@ class TestPsych < Psych::TestCase
   end
 
   def test_symbolize_names
-    result = Psych.load(<<-eoyml)
+    yaml = <<-eoyml
 foo:
   bar: baz
 hoge:
   - fuga: piyo
     eoyml
+
+    result = Psych.load(yaml)
     assert_equal result, { "foo" => { "bar" => "baz"}, "hoge" => [{ "fuga" => "piyo" }] }
 
-    result = Psych.load(<<-eoyml, symbolize_names: true)
-foo:
-  bar: baz
-hoge:
-  - fuga: piyo
-    eoyml
+    result = Psych.load(yaml, symbolize_names: true)
+    assert_equal result, { foo: { bar: "baz" }, hoge: [{ fuga: "piyo" }] }
+
+    result = Psych.safe_load(yaml, symbolize_names: true)
     assert_equal result, { foo: { bar: "baz" }, hoge: [{ fuga: "piyo" }] }
   end
 end


### PR DESCRIPTION
suggested at https://github.com/ruby/psych/pull/333#issuecomment-347689488

## Summary 
I added the same thing as #333 only for `.safe_load`.

## Notes
For `.load_file`, as it may take Hash object in existing arguments, we can't add `:symbolize_names` to it keeping backward compatibility (reason is described below).

<hr>

## The reason I didn't add the option to `Psych.load_file`
### Why adding `:symbolize_names` to `Psych.load_file` is incompatible?
#### before
```rb
File.write("test.yml", "")
Psych.load_file("test.yml", {}) #=> {}
```

#### after 
After adding `symbolize_names: false` to `.load_file` signature,

```rb
File.write("test.yml", "")
Psych.load_file("test.yml", {}) #=> false
```

`{}` is considered as empty keyword arguments, and second argument of `Psych.load_file` becomes `false`.

### Why adding it to `Psych.load` and `Psych.safe_load` is safe?
That's because `Psych.load` and `Psych.safe_load` don't take Hash object for normal usages.

Unlike `Psych.load_file`, `fallback` argument of `Psych.load` is NOT wrapped with `Psych::FALLBACK`. Thus, if you pass `{}` as `fallback`, `{}.to_ruby` will be called and it will be broken. So this method can't take `{}` (We should pass `Psych::FALLBACK.new({})` if we want to have `{}` as fallback).