### PR TITLE
Fix fallback argument for Psych.load

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -482,7 +482,7 @@ module Psych
   ###
   # Load the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
-  # the specified default return value, which defaults to an empty Hash
+  # the specified +fallback+ return value, which defaults to +false+.
   def self.load_file filename, fallback = false
     File.open(filename, 'r:bom|utf-8') { |f|
       self.load f, filename, FALLBACK.new(fallback)

--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -260,7 +260,7 @@ module Psych
   #   Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
   def self.load yaml, filename = nil, fallback = false, symbolize_names: false
-    result = parse(yaml, filename, fallback)
+    result = parse(yaml, filename, FALLBACK.new(fallback))
     result = result.to_ruby if result
     symbolize_names!(result) if symbolize_names
     result
@@ -485,7 +485,7 @@ module Psych
   # the specified +fallback+ return value, which defaults to +false+.
   def self.load_file filename, fallback = false
     File.open(filename, 'r:bom|utf-8') { |f|
-      self.load f, filename, FALLBACK.new(fallback)
+      self.load f, filename, fallback
     }
   end
 

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -135,6 +135,18 @@ class TestPsych < Psych::TestCase
     assert_equal({ 'hello' => 'world' }, got)
   end
 
+  def test_load_default_return_value
+    assert_equal false, Psych.load("")
+  end
+
+  def test_load_with_fallback
+    assert_equal 42, Psych.load("", "file", 42)
+  end
+
+  def test_load_with_fallback_hash
+    assert_equal Hash.new, Psych.load("", "file", Hash.new)
+  end
+
   def test_load_file
     Tempfile.create(['yikes', 'yml']) {|t|
       t.binmode

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -144,7 +144,19 @@ class TestPsych < Psych::TestCase
     }
   end
 
+  def test_load_file_default_return_value
+    Tempfile.create(['empty', 'yml']) {|t|
+      assert_equal false, Psych.load_file(t.path)
+    }
+  end
+
   def test_load_file_with_fallback
+    Tempfile.create(['empty', 'yml']) {|t|
+      assert_equal 42, Psych.load_file(t.path, 42)
+    }
+  end
+
+  def test_load_file_with_fallback_hash
     Tempfile.create(['empty', 'yml']) {|t|
       assert_equal Hash.new, Psych.load_file(t.path, Hash.new)
     }


### PR DESCRIPTION
**[WIP: depends on a solution to #340, see also below]**

@hsbt _I think this should be solved in the upcoming 3.0 release._

There is an error in the implementation of the fallback argument for Psych.load which causes an exception; it only works with Psych.load_file currently.

Before the fix:

``` ruby
$LOAD_PATH.unshift("./lib")

require "tempfile"
require "yaml"

Tempfile.create("empty") do |f|
  Psych.load_file(f)      # => false
end

Tempfile.create("empty") do |f|
  Psych.load_file(f, 42)  # => 42
end

Psych.load("")            # => false
Psych.load("", nil, 42)   # => NoMethodError: undefined method `to_ruby' for 42:Integer\nDid you mean?  to_r
```

However, it shouldn't make a difference whether the loaded yaml is read from a file or a string, so `load` and `load_file` should behave in the same way and both (or none) accept a fallback argument.

After the fix:

``` ruby
# ...

Psych.load("")            # => false
Psych.load("", nil, 42)   # => 42
```

**Problem**: This **will not work for hashes** currently, because of the (newly introduced) `symbolize_names` keyword argument for Psych.load. The keyword argument does not play well with the optional arguments. The provided hash is not parsed as the value for the optional `fallback` argument, unless the keyword argument is provided, too (see #340).

``` ruby
Psych.load("", nil, {})   # => false (!!!)
Psych.load("", nil, {}, symbolize_names: true)   # => {}
```

(This is the reason for the current test fails.)

BTW. @tenderlove mentioned in #149 and #264 that a default return value of `nil` might make more sense, but this could only be changed with a major release. 3.0?