### PR TITLE
Convert fallback option to a keyword argument

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -259,8 +259,8 @@ module Psych
   #   Psych.load("---\n foo: bar")                         # => {"foo"=>"bar"}
   #   Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
-  def self.load yaml, filename = nil, fallback = false, symbolize_names: false
-    result = parse(yaml, filename, fallback)
+  def self.load yaml, filename = nil, fallback: false, symbolize_names: false
+    result = parse(yaml, filename, fallback: fallback)
     result = result.to_ruby if result
     symbolize_names!(result) if symbolize_names
     result
@@ -336,7 +336,7 @@ module Psych
   #   end
   #
   # See Psych::Nodes for more information about YAML AST.
-  def self.parse yaml, filename = nil, fallback = false
+  def self.parse yaml, filename = nil, fallback: false
     parse_stream(yaml, filename) do |node|
       return node
     end
@@ -483,9 +483,9 @@ module Psych
   # Load the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
   # the specified default return value, which defaults to an empty Hash
-  def self.load_file filename, fallback = false
+  def self.load_file filename, fallback: false
     File.open(filename, 'r:bom|utf-8') { |f|
-      self.load f, filename, FALLBACK.new(fallback)
+      self.load f, filename, fallback: FALLBACK.new(fallback)
     }
   end
 

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -146,7 +146,7 @@ class TestPsych < Psych::TestCase
 
   def test_load_file_with_fallback
     Tempfile.create(['empty', 'yml']) {|t|
-      assert_equal Hash.new, Psych.load_file(t.path, Hash.new)
+      assert_equal Hash.new, Psych.load_file(t.path, fallback: Hash.new)
     }
   end
 


### PR DESCRIPTION
Converting the optional fallback argument to a keyword argument fixes a problem that is caused by mixing optional arguments and optional keyword arguments.

Without this change, a hash as fallback value is not handled correctly: in `Psych.load("", nil, {})` the hash is not interpreted as the fallback value, and the default value for the fallback argument is used instead.

This is a possible solution to the problems discussed in #340, #339, and #337.

This would break backwards compatibility, but that might be acceptable in the major version change to 3.0, and moreover I doubt that the fallback argument is widely used.