### PR TITLE
Add more test cases for fallback of Psych.load_file

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -492,7 +492,7 @@ module Psych
   ###
   # Load the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
-  # the specified default return value, which defaults to an empty Hash
+  # the specified +fallback+ return value, which defaults to +false+.
   def self.load_file filename, fallback: false
     File.open(filename, 'r:bom|utf-8') { |f|
       self.load f, filename, fallback: FALLBACK.new(fallback)

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -144,7 +144,19 @@ class TestPsych < Psych::TestCase
     }
   end
 
+  def test_load_file_default_return_value
+    Tempfile.create(['empty', 'yml']) {|t|
+      assert_equal false, Psych.load_file(t.path)
+    }
+  end
+
   def test_load_file_with_fallback
+    Tempfile.create(['empty', 'yml']) {|t|
+      assert_equal 42, Psych.load_file(t.path, fallback: 42)
+    }
+  end
+
+  def test_load_file_with_fallback_hash
     Tempfile.create(['empty', 'yml']) {|t|
       assert_equal Hash.new, Psych.load_file(t.path, fallback: Hash.new)
     }


### PR DESCRIPTION
Add more test cases for the fallback keyword argument of
Psych.load_file; additionally, fix an error in the docs.