### PR TITLE
Fix fallback keyword argument of Psych.load

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -236,8 +236,9 @@ module Psych
   ###
   # Load +yaml+ in to a Ruby data structure.  If multiple documents are
   # provided, the object contained in the first document will be returned.
-  # +filename+ will be used in the exception message if any exception is raised
-  # while parsing.
+  # +filename+ will be used in the exception message if any exception
+  # is raised while parsing.  If +yaml+ is empty, it returns
+  # the specified +fallback+ return value, which defaults to +false+.
   #
   # Raises a Psych::SyntaxError when a YAML syntax error is detected.
   #

--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -260,7 +260,7 @@ module Psych
   #   Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
   def self.load yaml, filename = nil, fallback: false, symbolize_names: false
-    result = parse(yaml, filename, fallback: fallback)
+    result = parse(yaml, filename, fallback: FALLBACK.new(fallback))
     result = result.to_ruby if result
     symbolize_names!(result) if symbolize_names
     result
@@ -513,7 +513,7 @@ module Psych
   # the specified +fallback+ return value, which defaults to +false+.
   def self.load_file filename, fallback: false
     File.open(filename, 'r:bom|utf-8') { |f|
-      self.load f, filename, fallback: FALLBACK.new(fallback)
+      self.load f, filename, fallback: fallback
     }
   end
 

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -135,6 +135,31 @@ class TestPsych < Psych::TestCase
     assert_equal({ 'hello' => 'world' }, got)
   end
 
+  def test_load_default_return_value
+    assert_equal false, Psych.load("")
+  end
+
+  def test_load_with_fallback
+    assert_equal 42, Psych.load("", "file", fallback: 42)
+  end
+
+  def test_load_with_fallback_nil_or_false
+    assert_nil Psych.load("", "file", fallback: nil)
+    assert_equal false, Psych.load("", "file", fallback: false)
+  end
+
+  def test_load_with_fallback_hash
+    assert_equal Hash.new, Psych.load("", "file", fallback: Hash.new)
+  end
+
+  def test_load_with_fallback_for_nil
+    assert_nil Psych.load("--- null", "file", fallback: 42)
+  end
+
+  def test_load_with_fallback_for_false
+    assert_equal false, Psych.load("--- false", "file", fallback: 42)
+  end
+
   def test_load_file
     Tempfile.create(['yikes', 'yml']) {|t|
       t.binmode


### PR DESCRIPTION
_This replaces #339, adapting it to the switch of the fallback positional argument to a keyword argument;
see discussions there._

There is an error in the implementation of the fallback argument for `Psych.load` which causes an exception; it only works with `Psych.load_file` as expected, currently.

Before the fix:

``` ruby
$LOAD_PATH.unshift("./lib")

require "tempfile"
require "yaml"

Tempfile.create("empty") do |f|
  Psych.load_file(f)                # => false
  Psych.load_file(f, fallback: 42)  # => 42
end

Psych.load("")                      # => false
Psych.load("", nil, fallback: 42)   # => NoMethodError: undefined method `to_ruby' for 42:Integer


# note that Psych.load's fallback can be made to work by wrapping the value like this:
Psych.load("", nil, fallback: Psych::FALLBACK.new(42))  # => 42
# but this strange and unexpected behaviour was never mentioned in any of
# the relevant issues or PRs, nor backed by test cases, nor documented.
# The different behaviour of the option for .load and .load_file clearly
# was not intended but is a bug.
```

After the fix:

``` ruby
Tempfile.create("empty") do |f|
  Psych.load_file(f)                # => false
  Psych.load_file(f, fallback: 42)  # => 42
end

Psych.load("")                      # => false
Psych.load("", nil, fallback: 42)   # => 42
```