### PR TITLE
Document Psych.dump options

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -418,6 +418,24 @@ module Psych
   # to control the output format.  If an IO object is passed in, the YAML will
   # be dumped to that IO object.
   #
+  # Currently supported options are:
+  #
+  # [<tt>:indentation</tt>]   Number of space characters used to indent.
+  #                           Acceptable value should be in <tt>0..9</tt> range,
+  #                           otherwise option is ignored.
+  #
+  #                           Default: <tt>2</tt>.
+  # [<tt>:line_width</tt>]    Max character to wrap line at.
+  #
+  #                           Default: <tt>0</tt> (meaning "wrap at 81").
+  # [<tt>:canonical</tt>]     Write "canonical" YAML form (very verbose, yet
+  #                           strictly formal).
+  #
+  #                           Default: <tt>false</tt>.
+  # [<tt>:header</tt>]        Write <tt>%YAML [version]</tt> at the beginning of document.
+  #
+  #                           Default: <tt>false</tt>.
+  #
   # Example:
   #
   #   # Dump an array, get back a YAML string
@@ -427,10 +445,10 @@ module Psych
   #   Psych.dump(['a', 'b'], StringIO.new)  # => #<StringIO:0x000001009d0890>
   #
   #   # Dump an array with indentation set
-  #   Psych.dump(['a', ['b']], :indentation => 3) # => "---\n- a\n-  - b\n"
+  #   Psych.dump(['a', ['b']], indentation: 3) # => "---\n- a\n-  - b\n"
   #
   #   # Dump an array to an IO with indentation set
-  #   Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
+  #   Psych.dump(['a', ['b']], StringIO.new, indentation: 3)
   def self.dump o, io = nil, options = {}
     if Hash === io
       options = io


### PR DESCRIPTION
`Psych.dump` options aren't documented anywhere, even despite the fact that there is an explicit reference to those non-existent docs in `Object#to_yaml`:

> See `Psych.dump` for more information on the available `options`.

I hope that I've extracted all possible options and their meaning from code correctly. The one option that intently left undocumented is `:version`, because currently, it seems to accept exactly one "correct" value: `"1.1"`, which is also the default value.

Rendered docs screenshot in default RDOC template:

![image](https://user-images.githubusercontent.com/129656/36896510-a8a03f5e-1e1b-11e8-8b46-5ba539898ac5.png)

BTW, shouldn't those options be turned into keyword arguments already? `.load` has keyword arguments, which is inconsistent with `.dump`.