### PR TITLE
Add more test cases for fallback of Psych.load_file

### DIFF
--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -162,6 +162,24 @@ class TestPsych < Psych::TestCase
     }
   end
 
+  def test_load_file_with_fallback_for_nil
+    Tempfile.create(['nil', 'yml']) {|t|
+      t.binmode
+      t.write('--- null')
+      t.close
+      assert_nil Psych.load_file(t.path, fallback: 42)
+    }
+  end
+
+  def test_load_file_with_fallback_for_false
+    Tempfile.create(['false', 'yml']) {|t|
+      t.binmode
+      t.write('--- false')
+      t.close
+      assert_equal false, Psych.load_file(t.path, fallback: 42)
+    }
+  end
+
   def test_parse_file
     Tempfile.create(['yikes', 'yml']) {|t|
       t.binmode


### PR DESCRIPTION
Add test cases for the fallback keyword argument of Psych.load_file to make sure that the fallback is not used for valid YAML that represents nil or false (as mentioned in #149).
