### PR TITLE
Add more test cases for fallback of Psych.load_file

### DIFF
--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -156,6 +156,13 @@ class TestPsych < Psych::TestCase
     }
   end
 
+  def test_load_file_with_fallback_nil_or_false
+    Tempfile.create(['empty', 'yml']) {|t|
+      assert_nil Psych.load_file(t.path, fallback: nil)
+      assert_equal false, Psych.load_file(t.path, fallback: false)
+    }
+  end
+
   def test_load_file_with_fallback_hash
     Tempfile.create(['empty', 'yml']) {|t|
       assert_equal Hash.new, Psych.load_file(t.path, fallback: Hash.new)


### PR DESCRIPTION
Add test cases for the fallback keyword argument of Psych.load_file to make sure that a falsy fallback (nil or false) works properly. (Another edge case that might cause regressions in case of implementation changes.)