### PR TITLE
Add Deprecation Warnings to the unified interface of Psych

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -265,6 +265,7 @@ module Psych
   #
   def self.load yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: false, symbolize_names: false
     if legacy_filename != NOT_GIVEN
+      warn 'warning: Passing filename with the 2nd argument of Psych.load is deprecated. Use keyword argument like Psych.load(yaml, filename: ...) instead.'
       filename = legacy_filename
     end
 
@@ -321,18 +322,22 @@ module Psych
   #
   def self.safe_load yaml, legacy_whitelist_classes = NOT_GIVEN, legacy_whitelist_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, whitelist_classes: [], whitelist_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false
     if legacy_whitelist_classes != NOT_GIVEN
+      warn 'warning: Passing whitelist_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_classes: ...) instead.'
       whitelist_classes = legacy_whitelist_classes
     end
 
     if legacy_whitelist_symbols != NOT_GIVEN
+      warn 'warning: Passing whitelist_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_symbols: ...) instead.'
       whitelist_symbols = legacy_whitelist_symbols
     end
 
     if legacy_aliases != NOT_GIVEN
+      warn 'warning: Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.'
       aliases = legacy_aliases
     end
 
     if legacy_filename != NOT_GIVEN
+      warn 'warning: Passing filename with the 5th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, filename: ...) instead.'
       filename = legacy_filename
     end
 
@@ -373,6 +378,7 @@ module Psych
   # See Psych::Nodes for more information about YAML AST.
   def self.parse yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: NOT_GIVEN
     if legacy_filename != NOT_GIVEN
+      warn 'warning: Passing filename with the 2nd argument of Psych.parse is deprecated. Use keyword argument like Psych.parse(yaml, filename: ...) instead.'
       filename = legacy_filename
     end
 
@@ -381,6 +387,7 @@ module Psych
     end
 
     if fallback != NOT_GIVEN
+      warn 'warning: Passing the `fallback` keyword argument of Psych.parse is deprecated.'
       fallback
     else
       false
@@ -435,6 +442,7 @@ module Psych
   # See Psych::Nodes for more information about YAML AST.
   def self.parse_stream yaml, legacy_filename = NOT_GIVEN, filename: nil, &block
     if legacy_filename != NOT_GIVEN
+      warn 'warning: Passing filename with the 2nd argument of Psych.parse_stream is deprecated. Use keyword argument like Psych.parse_stream(yaml, filename: ...) instead.'
       filename = legacy_filename
     end
 
@@ -540,6 +548,7 @@ module Psych
   #
   def self.load_stream yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: []
     if legacy_filename != NOT_GIVEN
+      warn 'warning: Passing filename with the 2nd argument of Psych.load_stream is deprecated. Use keyword argument like Psych.load_stream(yaml, filename: ...) instead.'
       filename = legacy_filename
     end
 


### PR DESCRIPTION
This is a follow up to https://github.com/ruby/psych/pull/358

@tenderlove @yuki24 

# Goal
- Add deprecation warning to the new interface changes

# Follow Up
- Remove the old interface args



_Note_: Once #358 ships, only the `warn` lines will be left