### PR TITLE
 Add comment for require fallback in Ruby repository; fix typo

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Psych
-  # The version is Psych you're using
+  # The version of Psych you are using
   VERSION = '3.1.0.pre1' unless defined?(::Psych::VERSION)
 
   if RUBY_ENGINE == 'jruby'

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -4,6 +4,7 @@
 begin
   require_relative 'lib/psych/versions'
 rescue LoadError
+  # for Ruby core repository
   require_relative 'versions'
 end
 


### PR DESCRIPTION
The fallback for LoadError in the gemspec is somewhat cryptic without a hint regarding its purpose.