### PR TITLE
Use friendlier terminology in YAML.safe_load

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,10 @@
+Thu Nov  8 12:00:00 2018  Juanito Fatas <me@juanitofatas.com>
+
+  * lib/psych.rb: Use friendlier terminology in YAML.safe_load.
+    Replace keyword argumment whitelist_classes and whitelist_symbols.
+    with permitted_classes and permitted_symbols.
+  * test/psych/test_safer_load.rb: Update tests accordingly.
+
 Fri Feb  6 17:47:05 2015  Aaron Patterson <aaron@tenderlovemaking.com>
 
 	* ext/psych/lib/psych/visitors/yaml_tree.rb: register nodes when

--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -294,10 +294,10 @@ module Psych
   # * Hash
   #
   # Recursive data structures are not allowed by default.  Arbitrary classes
-  # can be allowed by adding those classes to the +whitelist_classes+ keyword argument.  They are
+  # can be allowed by adding those classes to the +permitted_classes+ keyword argument.  They are
   # additive.  For example, to allow Date deserialization:
   #
-  #   Psych.safe_load(yaml, whitelist_classes: [Date])
+  #   Psych.safe_load(yaml, permitted_classes: [Date])
   #
   # Now the Date class can be loaded in addition to the classes listed above.
   #
@@ -311,7 +311,7 @@ module Psych
   #   Psych.safe_load yaml, aliases: true # => loads the aliases
   #
   # A Psych::DisallowedClass exception will be raised if the yaml contains a
-  # class that isn't in the whitelist.
+  # class that isn't in the +permitted_classes+ list.
   #
   # A Psych::BadAlias exception will be raised if the yaml contains aliases
   # but the +aliases+ keyword argument is set to false.
@@ -325,15 +325,15 @@ module Psych
   #   Psych.safe_load("---\n foo: bar")                         # => {"foo"=>"bar"}
   #   Psych.safe_load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
-  def self.safe_load yaml, legacy_whitelist_classes = NOT_GIVEN, legacy_whitelist_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, whitelist_classes: [], whitelist_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false
-    if legacy_whitelist_classes != NOT_GIVEN
-      warn 'warning: Passing whitelist_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_classes: ...) instead.'
-      whitelist_classes = legacy_whitelist_classes
+  def self.safe_load yaml, legacy_permitted_classes = NOT_GIVEN, legacy_permitted_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false
+    if legacy_permitted_classes != NOT_GIVEN
+      warn 'warning: Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.'
+      permitted_classes = legacy_permitted_classes
     end
 
-    if legacy_whitelist_symbols != NOT_GIVEN
-      warn 'warning: Passing whitelist_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_symbols: ...) instead.'
-      whitelist_symbols = legacy_whitelist_symbols
+    if legacy_permitted_symbols != NOT_GIVEN
+      warn 'warning: Passing permitted_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_symbols: ...) instead.'
+      permitted_symbols = legacy_permitted_symbols
     end
 
     if legacy_aliases != NOT_GIVEN
@@ -349,8 +349,8 @@ module Psych
     result = parse(yaml, filename: filename)
     return fallback unless result
 
-    class_loader = ClassLoader::Restricted.new(whitelist_classes.map(&:to_s),
-                                               whitelist_symbols.map(&:to_s))
+    class_loader = ClassLoader::Restricted.new(permitted_classes.map(&:to_s),
+                                               permitted_symbols.map(&:to_s))
     scanner      = ScalarScanner.new class_loader
     visitor = if aliases
                 Visitors::ToRuby.new scanner, class_loader

--- a/test/psych/test_safe_load.rb
+++ b/test/psych/test_safe_load.rb
@@ -30,12 +30,12 @@ module Psych
     def test_explicit_recursion
       x = []
       x << x
-      assert_equal(x, Psych.safe_load(Psych.dump(x), whitelist_classes: [], whitelist_symbols: [], aliases: true))
+      assert_equal(x, Psych.safe_load(Psych.dump(x), permitted_classes: [], permitted_symbols: [], aliases: true))
       # deprecated interface
       assert_equal(x, Psych.safe_load(Psych.dump(x), [], [], true))
     end
 
-    def test_symbol_whitelist
+    def test_permitted_symbol
       yml = Psych.dump :foo
       assert_raises(Psych::DisallowedClass) do
         Psych.safe_load yml
@@ -44,8 +44,8 @@ module Psych
         :foo,
         Psych.safe_load(
           yml,
-          whitelist_classes: [Symbol],
-          whitelist_symbols: [:foo]
+          permitted_classes: [Symbol],
+          permitted_symbols: [:foo]
         )
       )
 
@@ -58,7 +58,7 @@ module Psych
         assert_safe_cycle :foo
       end
       assert_raises(Psych::DisallowedClass) do
-        Psych.safe_load '--- !ruby/symbol foo', whitelist_classes: []
+        Psych.safe_load '--- !ruby/symbol foo', permitted_classes: []
       end
 
       # deprecated interface
@@ -66,9 +66,9 @@ module Psych
         Psych.safe_load '--- !ruby/symbol foo', []
       end
 
-      assert_safe_cycle :foo, whitelist_classes: [Symbol]
-      assert_safe_cycle :foo, whitelist_classes: %w{ Symbol }
-      assert_equal :foo, Psych.safe_load('--- !ruby/symbol foo', whitelist_classes: [Symbol])
+      assert_safe_cycle :foo, permitted_classes: [Symbol]
+      assert_safe_cycle :foo, permitted_classes: %w{ Symbol }
+      assert_equal :foo, Psych.safe_load('--- !ruby/symbol foo', permitted_classes: [Symbol])
 
       # deprecated interface
       assert_equal :foo, Psych.safe_load('--- !ruby/symbol foo', [Symbol])
@@ -76,7 +76,7 @@ module Psych
 
     def test_foo
       assert_raises(Psych::DisallowedClass) do
-        Psych.safe_load '--- !ruby/object:Foo {}', whitelist_classes: [Foo]
+        Psych.safe_load '--- !ruby/object:Foo {}', permitted_classes: [Foo]
       end
 
       # deprecated interface
@@ -87,7 +87,7 @@ module Psych
       assert_raises(Psych::DisallowedClass) do
         assert_safe_cycle Foo.new
       end
-      assert_kind_of(Foo, Psych.safe_load(Psych.dump(Foo.new), whitelist_classes: [Foo]))
+      assert_kind_of(Foo, Psych.safe_load(Psych.dump(Foo.new), permitted_classes: [Foo]))
 
       # deprecated interface
       assert_kind_of(Foo, Psych.safe_load(Psych.dump(Foo.new), [Foo]))
@@ -95,27 +95,27 @@ module Psych
 
     X = Struct.new(:x)
     def test_struct_depends_on_sym
-      assert_safe_cycle(X.new, whitelist_classes: [X, Symbol])
+      assert_safe_cycle(X.new, permitted_classes: [X, Symbol])
       assert_raises(Psych::DisallowedClass) do
-        cycle X.new, whitelist_classes: [X]
+        cycle X.new, permitted_classes: [X]
       end
     end
 
     def test_anon_struct
-      assert Psych.safe_load(<<-eoyml, whitelist_classes: [Struct, Symbol])
+      assert Psych.safe_load(<<-eoyml, permitted_classes: [Struct, Symbol])
 --- !ruby/struct
   foo: bar
                       eoyml
 
       assert_raises(Psych::DisallowedClass) do
-        Psych.safe_load(<<-eoyml, whitelist_classes: [Struct])
+        Psych.safe_load(<<-eoyml, permitted_classes: [Struct])
 --- !ruby/struct
   foo: bar
                       eoyml
       end
 
       assert_raises(Psych::DisallowedClass) do
-        Psych.safe_load(<<-eoyml, whitelist_classes: [Symbol])
+        Psych.safe_load(<<-eoyml, permitted_classes: [Symbol])
 --- !ruby/struct
   foo: bar
                       eoyml
@@ -157,14 +157,14 @@ module Psych
 
     private
 
-    def cycle object, whitelist_classes: []
-      Psych.safe_load(Psych.dump(object), whitelist_classes: whitelist_classes)
+    def cycle object, permitted_classes: []
+      Psych.safe_load(Psych.dump(object), permitted_classes: permitted_classes)
       # deprecated interface test
-      Psych.safe_load(Psych.dump(object), whitelist_classes)
+      Psych.safe_load(Psych.dump(object), permitted_classes)
     end
 
-    def assert_safe_cycle object, whitelist_classes: []
-      other = cycle object, whitelist_classes: whitelist_classes
+    def assert_safe_cycle object, permitted_classes: []
+      other = cycle object, permitted_classes: permitted_classes
       assert_equal object, other
     end
   end


### PR DESCRIPTION
This Pull Request deprecates the usage of whitelist. Prefer Permitted over Whitelist where applicable.

Permitted is easier to understand and better terminology.

[Original motivation](https://github.com/rails/rails/issues/33677), community efforts examples:

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/ruby/pull/2008
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/rack/rack/pull/1314
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubocop-hq/rubocop/pull/6466
- https://github.com/rubocop-hq/rubocop/pull/6467
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/flavorjones/loofah/pull/158
- https://github.com/pry/pry/pull/1874
- https://github.com/pry/pry/pull/1875