### PR TITLE
Add uplelvel to deprecation warning of Psych

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -270,7 +270,7 @@ module Psych
   #
   def self.load yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: false, symbolize_names: false
     if legacy_filename != NOT_GIVEN
-      warn 'warning: Passing filename with the 2nd argument of Psych.load is deprecated. Use keyword argument like Psych.load(yaml, filename: ...) instead.'
+      warn_with_uplevel 'Passing filename with the 2nd argument of Psych.load is deprecated. Use keyword argument like Psych.load(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
     end
 
@@ -327,22 +327,22 @@ module Psych
   #
   def self.safe_load yaml, legacy_permitted_classes = NOT_GIVEN, legacy_permitted_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false
     if legacy_permitted_classes != NOT_GIVEN
-      warn 'warning: Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.'
+      warn_with_uplevel 'Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.', uplevel: 1 if $VERBOSE
       permitted_classes = legacy_permitted_classes
     end
 
     if legacy_permitted_symbols != NOT_GIVEN
-      warn 'warning: Passing permitted_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_symbols: ...) instead.'
+      warn_with_uplevel 'Passing permitted_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_symbols: ...) instead.', uplevel: 1 if $VERBOSE
       permitted_symbols = legacy_permitted_symbols
     end
 
     if legacy_aliases != NOT_GIVEN
-      warn 'warning: Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.'
+      warn_with_uplevel 'Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.', uplevel: 1 if $VERBOSE
       aliases = legacy_aliases
     end
 
     if legacy_filename != NOT_GIVEN
-      warn 'warning: Passing filename with the 5th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, filename: ...) instead.'
+      warn_with_uplevel 'Passing filename with the 5th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
     end
 
@@ -383,7 +383,7 @@ module Psych
   # See Psych::Nodes for more information about YAML AST.
   def self.parse yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: NOT_GIVEN
     if legacy_filename != NOT_GIVEN
-      warn 'warning: Passing filename with the 2nd argument of Psych.parse is deprecated. Use keyword argument like Psych.parse(yaml, filename: ...) instead.'
+      warn_with_uplevel 'Passing filename with the 2nd argument of Psych.parse is deprecated. Use keyword argument like Psych.parse(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
     end
 
@@ -392,7 +392,7 @@ module Psych
     end
 
     if fallback != NOT_GIVEN
-      warn 'warning: Passing the `fallback` keyword argument of Psych.parse is deprecated.'
+      warn_with_uplevel 'Passing the `fallback` keyword argument of Psych.parse is deprecated.', uplevel: 1 if $VERBOSE
       fallback
     else
       false
@@ -447,7 +447,7 @@ module Psych
   # See Psych::Nodes for more information about YAML AST.
   def self.parse_stream yaml, legacy_filename = NOT_GIVEN, filename: nil, &block
     if legacy_filename != NOT_GIVEN
-      warn 'warning: Passing filename with the 2nd argument of Psych.parse_stream is deprecated. Use keyword argument like Psych.parse_stream(yaml, filename: ...) instead.'
+      warn_with_uplevel 'Passing filename with the 2nd argument of Psych.parse_stream is deprecated. Use keyword argument like Psych.parse_stream(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
     end
 
@@ -553,7 +553,7 @@ module Psych
   #
   def self.load_stream yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: []
     if legacy_filename != NOT_GIVEN
-      warn 'warning: Passing filename with the 2nd argument of Psych.load_stream is deprecated. Use keyword argument like Psych.load_stream(yaml, filename: ...) instead.'
+      warn_with_uplevel 'Passing filename with the 2nd argument of Psych.load_stream is deprecated. Use keyword argument like Psych.load_stream(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
     end
 
@@ -616,6 +616,21 @@ module Psych
     result
   end
   private_class_method :symbolize_names!
+
+  # Workaround for emulating `warn '...', uplevel: 1` in Ruby 2.4 or lower.
+  def self.warn_with_uplevel(message, uplevel: 1)
+    at = parse_caller(caller[uplevel]).join(':')
+    warn "#{at}: #{message}"
+  end
+
+  def self.parse_caller(at)
+    if /^(.+?):(\d+)(?::in `.*')?/ =~ at
+      file = $1
+      line = $2.to_i
+      [file, line]
+    end
+  end
+  private_class_method :warn_with_uplevel, :parse_caller
 
   class << self
     attr_accessor :load_tags


### PR DESCRIPTION
This is porting ruby/ruby#1992 to upstream.

This PR adds `uplelvel` to deprecation warning of Psych.
The `uplevel` option was introduced from Ruby 2.5. ruby/psych needs to support Ruby 2.4 or lower.

This PR has `warn_with_uplevel` method emulating `warn 'message', uplevel: 1` in Ruby 2.4 or lower.

And this PR relaxes the warning.
https://github.com/ruby/ruby/pull/1992#discussion_r227214370

## Summary

The deprecation warning log has been added the following commit.
https://github.com/ruby/ruby/commit/1c92766bf0b7394057c00f576fce5464a3037fd9

The following is deprecation warning log change.

### Example code

```console
% cat /tmp/psych_example.rb
require 'psych'

Psych.load("--- foo\n", nil)
```

### Before

```console
% ruby -v
ruby 2.6.0dev (2018-10-21 trunk 65252) [x86_64-darwin17]

% ruby /tmp/psych_example.rb
warning: Passing filename with the 2nd argument of Psych.load is
deprecated. Use keyword argument like Psych.load(yaml, filename: ...)
instead.
```

### After

This patch helps detect argument locations that are deprecated usage.

```console
% cd /path/to/ruby/repo
% make install
% /usr/local/bin/ruby /tmp/psych_example.rb
/tmp/psych_example.rb:3: warning: Passing filename with the 2nd
argument of Psych.load is deprecated. Use keyword argument like
Psych.load(yaml, filename: ...) instead.
```

## Other Information

This log format refers to the deprecation warning of `ERB.new` in Ruby 2.6+.
https://github.com/ruby/ruby/blob/v2_6_0_preview2/lib/erb.rb#L808