### PR TITLE
Exception backtraces should round trip

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -252,6 +252,8 @@ module Psych
 
           e = build_exception((resolve_class($1) || class_loader.exception),
                               h.delete('message'))
+
+          e.set_backtrace h.delete('backtrace') if h.key? 'backtrace'
           init_with(e, h, o)
 
         when '!set', 'tag:yaml.org,2002:set'

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -181,37 +181,11 @@ module Psych
       end
 
       def visit_Exception o
-        tag = ['!ruby/exception', o.class.name].join ':'
-
-        @emitter.start_mapping nil, tag, false, Nodes::Mapping::BLOCK
-
-        msg = private_iv_get(o, 'mesg')
-
-        if msg
-          @emitter.scalar 'message', nil, nil, true, false, Nodes::Scalar::ANY
-          accept msg
-        end
-
-        dump_ivars o
-
-        @emitter.end_mapping
+        dump_exception o, private_iv_get(o, 'mesg')
       end
 
       def visit_NameError o
-        tag = ['!ruby/exception', o.class.name].join ':'
-
-        @emitter.start_mapping nil, tag, false, Nodes::Mapping::BLOCK
-
-        msg = o.message.to_s
-
-        if msg
-          @emitter.scalar 'message', nil, nil, true, false, Nodes::Scalar::ANY
-          accept msg
-        end
-
-        dump_ivars o
-
-        @emitter.end_mapping
+        dump_exception o, o.message.to_s
       end
 
       def visit_Regexp o
@@ -486,6 +460,21 @@ module Psych
       end
 
       def dump_list o
+      end
+
+      def dump_exception o, msg
+        tag = ['!ruby/exception', o.class.name].join ':'
+
+        @emitter.start_mapping nil, tag, false, Nodes::Mapping::BLOCK
+
+        if msg
+          @emitter.scalar 'message', nil, nil, true, false, Nodes::Scalar::ANY
+          accept msg
+        end
+
+        dump_ivars o
+
+        @emitter.end_mapping
       end
 
       def format_time time

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -472,6 +472,9 @@ module Psych
           accept msg
         end
 
+        @emitter.scalar 'backtrace', nil, nil, true, false, Nodes::Scalar::ANY
+        accept o.backtrace
+
         dump_ivars o
 
         @emitter.end_mapping

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -185,13 +185,11 @@ module Psych
 
         @emitter.start_mapping nil, tag, false, Nodes::Mapping::BLOCK
 
-        {
-          'message'   => private_iv_get(o, 'mesg'),
-          'backtrace' => private_iv_get(o, 'backtrace'),
-        }.each do |k,v|
-          next unless v
-          @emitter.scalar k, nil, nil, true, false, Nodes::Scalar::ANY
-          accept v
+        msg = private_iv_get(o, 'mesg')
+
+        if msg
+          @emitter.scalar 'message', nil, nil, true, false, Nodes::Scalar::ANY
+          accept msg
         end
 
         dump_ivars o
@@ -204,13 +202,11 @@ module Psych
 
         @emitter.start_mapping nil, tag, false, Nodes::Mapping::BLOCK
 
-        {
-          'message'   => o.message.to_s,
-          'backtrace' => private_iv_get(o, 'backtrace'),
-        }.each do |k,v|
-          next unless v
-          @emitter.scalar k, nil, nil, true, false, Nodes::Scalar::ANY
-          accept v
+        msg = o.message.to_s
+
+        if msg
+          @emitter.scalar 'message', nil, nil, true, false, Nodes::Scalar::ANY
+          accept msg
         end
 
         dump_ivars o

--- a/test/psych/test_exception.rb
+++ b/test/psych/test_exception.rb
@@ -23,6 +23,20 @@ module Psych
       $VERBOSE = @orig_verbose
     end
 
+    def make_ex msg = 'oh no!'
+      begin
+        raise msg
+      rescue ::Exception => e
+        e
+      end
+    end
+
+    def test_backtrace
+      err     = make_ex
+      new_err = Psych.load(Psych.dump(err))
+      assert_equal err.backtrace, new_err.backtrace
+    end
+
     def test_naming_exception
       err     = String.xxx rescue $!
       new_err = Psych.load(Psych.dump(err))


### PR DESCRIPTION
Psych should round-trip exception backtraces.  If an exception has a backtrace, it should be available after dumping to yaml and reading from yaml