### PR TITLE
Add test to demonstrate issue deserializing hash with ivar

### DIFF
--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -6,6 +6,18 @@ module Psych
     class X < Hash
     end
 
+    class HashWithIvar < Hash
+      def initialize
+        @keys = []
+        super
+      end
+
+      def []=(k, v)
+        @keys << k
+        super(k, v)
+      end
+    end
+
     class HashWithCustomInit < Hash
       attr_reader :obj
       def initialize(obj)
@@ -22,6 +34,14 @@ module Psych
     def setup
       super
       @hash = { :a => 'b' }
+    end
+
+    def test_hash_with_ivar
+      t1 = HashWithIvar.new
+      t1[:foo] = :bar
+      t2 = Psych.load(Psych.dump(t1))
+      assert_equal t1, t2
+      assert_cycle t1
     end
 
     def test_referenced_hash_with_ivar


### PR DESCRIPTION
Currently the elements of a hash are revived before any ivar values. This causes an issue when the `[]=` method references an instance variable. To correct this issue, `ivars` should be set on an allocated object before attempting to set `elements` when deserializing.

Relevant code: https://github.com/ruby/psych/blob/63c94cf4f1a877a84c9bbed2ccabc773f9e56035/lib/psych/visitors/to_ruby.rb#L267