### PR TITLE
Dump ivars befor hash elements

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -428,21 +428,21 @@ module Psych
           node = @emitter.start_mapping(nil, tag, false, Psych::Nodes::Mapping::BLOCK)
           register(o, node)
 
-          # Dump the elements
-          accept 'elements'
-          @emitter.start_mapping nil, nil, true, Nodes::Mapping::BLOCK
-          o.each do |k,v|
-            accept k
-            accept v
-          end
-          @emitter.end_mapping
-
           # Dump the ivars
           accept 'ivars'
           @emitter.start_mapping nil, nil, true, Nodes::Mapping::BLOCK
           o.instance_variables.each do |ivar|
             accept ivar
             accept o.instance_variable_get ivar
+          end
+          @emitter.end_mapping
+
+          # Dump the elements
+          accept 'elements'
+          @emitter.start_mapping nil, nil, true, Nodes::Mapping::BLOCK
+          o.each do |k,v|
+            accept k
+            accept v
           end
           @emitter.end_mapping
 

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -6,6 +6,18 @@ module Psych
     class X < Hash
     end
 
+    class HashWithIvar < Hash
+      def initialize
+        @keys = []
+        super
+      end
+
+      def []=(k, v)
+        @keys << k
+        super(k, v)
+      end
+    end
+
     class HashWithCustomInit < Hash
       attr_reader :obj
       def initialize(obj)
@@ -22,6 +34,14 @@ module Psych
     def setup
       super
       @hash = { :a => 'b' }
+    end
+
+    def test_hash_with_ivar
+      t1 = HashWithIvar.new
+      t1[:foo] = :bar
+      t2 = Psych.load(Psych.dump(t1))
+      assert_equal t1, t2
+      assert_cycle t1
     end
 
     def test_referenced_hash_with_ivar


### PR DESCRIPTION
Dump ivars before hash elements so that has elements that depend on ivars when being revived will work.