### PR TITLE
avoid false const warnings (when using bundler)

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 module Psych
   # The version of Psych you are using
-  VERSION = '3.1.0' unless defined?(::Psych::VERSION)
+  VERSION = '3.1.0'
 
   DEFAULT_SNAKEYAML_VERSION = '1.23' if RUBY_ENGINE == 'jruby'
 end

--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -4,7 +4,5 @@ module Psych
   # The version of Psych you are using
   VERSION = '3.1.0' unless defined?(::Psych::VERSION)
 
-  if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '1.23'.freeze
-  end
+  DEFAULT_SNAKEYAML_VERSION = '1.23' if RUBY_ENGINE == 'jruby'
 end

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -1,16 +1,16 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
-begin
-  require_relative 'lib/psych/versions'
-rescue LoadError
-  # for Ruby core repository
-  require_relative 'versions'
-end
+versions = File.expand_path('lib/psych/versions.rb', File.dirname(__FILE__))
+versions = File.read(versions)
+versions =
+  { VERSION: nil, DEFAULT_SNAKEYAML_VERSION: nil }.map do |const, _|
+    [ const, versions.match( /.*\s#{const}\s*=\s*['"](.*?)['"]/ )[1] ]
+  end.to_h
 
 Gem::Specification.new do |s|
   s.name = "psych"
-  s.version = Psych::VERSION
+  s.version = versions[:VERSION]
   s.authors = ["Aaron Patterson", "SHIBATA Hiroshi", "Charles Oliver Nutter"]
   s.email = ["aaron@tenderlovemaking.com", "hsbt@ruby-lang.org", "headius@headius.com"]
   s.summary = "Psych is a YAML parser and emitter"
@@ -65,7 +65,7 @@ DESCRIPTION
       "lib/psych_jars.rb",
       "lib/psych.jar"
     ]
-    s.requirements = "jar org.yaml:snakeyaml, #{Psych::DEFAULT_SNAKEYAML_VERSION}"
+    s.requirements = "jar org.yaml:snakeyaml, #{versions[:DEFAULT_SNAKEYAML_VERSION] || raise}"
     s.add_dependency 'jar-dependencies', '>= 0.1.7'
     s.add_development_dependency 'ruby-maven'
   else


### PR DESCRIPTION
Bundler will load YAML and thus Psych, which causes *versions.rb* to be
required, but than it also loads the psych.gemspec ... (loading .rb twice)

in such case, the reported version constants might not be accurate
and also causes warnings due double loading of the same *versions.rb*

this is really annoying and the `unless defined?(VERSION)` is not really a good solution
(have been confused by the psych version used - depends on LOAD_PATH entries order)