### PR TITLE
Speed up loading psych gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,8 @@ if RUBY_PLATFORM =~ /java/
 else
   require 'rake/extensiontask'
   spec = Gem::Specification.load("psych.gemspec")
+  # Add stub/ on $LOAD_PATH only for binary gems
+  spec.require_paths.insert(0, *%w[stub])
   Rake::ExtensionTask.new("psych", spec) do |ext|
     ext.lib_dir = File.join(*['lib', ENV['FAT_DIR']].compact)
     ext.cross_compile = true

--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -1,21 +1,22 @@
 # frozen_string_literal: true
 require 'psych/versions'
-case RUBY_ENGINE
-when 'jruby'
-  require 'psych_jars'
-  if JRuby::Util.respond_to?(:load_ext)
-    JRuby::Util.load_ext('org.jruby.ext.psych.PsychLibrary')
+
+# When required from the stub file, the C extension is already loaded
+unless caller_locations(1, 1)[0].absolute_path == File.expand_path('../stub/psych.rb', __dir__)
+  case RUBY_ENGINE
+  when 'jruby'
+    require 'psych_jars'
+    if JRuby::Util.respond_to?(:load_ext)
+      JRuby::Util.load_ext('org.jruby.ext.psych.PsychLibrary')
+    else
+      require 'java'; require 'jruby'
+      org.jruby.ext.psych.PsychLibrary.new.load(JRuby.runtime, false)
+    end
   else
-    require 'java'; require 'jruby'
-    org.jruby.ext.psych.PsychLibrary.new.load(JRuby.runtime, false)
-  end
-else
-  begin
-    require "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
-  rescue LoadError
     require 'psych.so'
   end
 end
+
 require 'psych/nodes'
 require 'psych/streaming'
 require 'psych/visitors'

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -41,7 +41,8 @@ DESCRIPTION
     "lib/psych/set.rb", "lib/psych/stream.rb", "lib/psych/streaming.rb", "lib/psych/syntax_error.rb",
     "lib/psych/tree_builder.rb", "lib/psych/versions.rb", "lib/psych/visitors.rb","lib/psych/visitors/depth_first.rb",
     "lib/psych/visitors/emitter.rb", "lib/psych/visitors/json_tree.rb", "lib/psych/visitors/to_ruby.rb",
-    "lib/psych/visitors/visitor.rb", "lib/psych/visitors/yaml_tree.rb", "lib/psych/y.rb", "psych.gemspec"
+    "lib/psych/visitors/visitor.rb", "lib/psych/visitors/yaml_tree.rb", "lib/psych/y.rb", "psych.gemspec",
+    "stub/psych.rb"
   ]
 
   s.rdoc_options = ["--main", "README.md"]

--- a/stub/psych.rb
+++ b/stub/psych.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# This file is only on $LOAD_PATH when using a binary gem
+
+require "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
+require_relative '../lib/psych'


### PR DESCRIPTION
This patch drastically reduces time taken to load the gem in all non-Windows platforms by bypassing the versioned .so require attempt that is necessary only for binary gems.

On my local Mac machine, requiring psych gem became 5x faster with this patch (this may change depending on number of gems being installed there).

```
ruby -e "now = Time.now; gem 'psych', '3.1.0'; require 'psych'; p '3.1.0' => Time.now - now"
ruby -e "now = Time.now; gem 'psych', '3.1.1'; require 'psych'; p '3.1.1' => Time.now - now"

{"3.1.0"=>0.186081}
{"3.1.1"=>0.037546}
```

I guess we actually achieved a huge ✌️, because almost everyone using Ruby on Linux, Mac, and such gets 150ms-ish speed up for free on some Ruby-made command execution, like `gem install`, `rails`, etcetc.

This excellent idea was implemented by @nobu for io-console gem, and already included in its 0.4.8 release.
https://github.com/ruby/io-console/pull/4