### PR TITLE
Deduplicate hash keys if they're strings

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -336,7 +336,7 @@ module Psych
       SHOVEL = '<<'
       def revive_hash hash, o
         o.children.each_slice(2) { |k,v|
-          key = accept(k)
+          key = deduplicate(accept(k))
           val = accept(v)
 
           if key == SHOVEL && k.tag != "tag:yaml.org,2002:str"
@@ -366,6 +366,28 @@ module Psych
 
         }
         hash
+      end
+
+      if String.method_defined?(:-@)
+        def deduplicate key
+          if key.is_a?(String)
+            # It is important to untaint the string, otherwise it won't
+            # be deduplicated into and fstring, but simply frozen.
+            -(key.untaint)
+          else
+            key
+          end
+        end
+      else
+        def deduplicate key
+          if key.is_a?(String)
+            # Deduplication is not supported by this implementation,
+            # but we emulate it's side effects
+            key.untaint.freeze
+          else
+            key
+          end
+        end
       end
 
       def merge_key hash, key, val

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -111,5 +111,19 @@ bar:
 eoyml
       assert_equal({"foo"=>{"hello"=>"world"}, "bar"=>{"hello"=>"world"}}, hash)
     end
+
+    def test_key_deduplication
+      unless String.method_defined?(:-@) && (-("a" * 20)).equal?((-("a" * 20)))
+        skip "This Ruby implementation doesn't support string deduplication"
+      end
+
+      hashes = Psych.load(<<-eoyml)
+---
+- unique_identifier: 1
+- unique_identifier: 2
+eoyml
+
+      assert_same hashes[0].keys.first, hashes[1].keys.first
+    end
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/ruby/ruby/pull/2287#issuecomment-513405834

### Usage

It's fairly common for YAML documents to contain several hashes with similar keys, e.g.:

```yaml
- name: George
  role: admin
- name: Peter
  role: user
```

In such scenarios, the returned datastructure will contain two instances of `"name"` and two instances `"role"`. Assuming the structure will potentially be kept in memory for the program lifetime, it's wasted space. 

### The patch

Since a very long time, MRI automatically freezes strings when they are used as hash keys. e.g. it's equivalent to `key.dup.freeze`.

As such we can apply [`String#-@`](https://ruby-doc.org/core-2.6.3/String.html#method-i-2D-40) to deduplicate it first, without breaking backward compatibility.

### Potential followup

It could be interesting to also deduplicate String values, however since it implies freezing them, it would break backward compatibility. As such I assume it would need to be behind some flag.

@tenderlove @Edouard-chin @rafaelfranca