### PR TITLE
Suppress uninitialized instance variable warnings

### DIFF
--- a/test/psych/visitors/test_yaml_tree.rb
+++ b/test/psych/visitors/test_yaml_tree.rb
@@ -7,7 +7,7 @@ module Psych
       class TestDelegatorClass < Delegator
         def initialize(obj); super; @obj = obj; end
         def __setobj__(obj); @obj = obj; end
-        def __getobj__; @obj; end
+        def __getobj__; @obj if defined?(@obj); end
       end
 
       class TestSimpleDelegatorClass < SimpleDelegator


### PR DESCRIPTION
In verbose mode, `test_delegator` in `test/psych/visitors/test_yaml_tree.rb` shows following warning.

https://travis-ci.org/ruby/psych/jobs/562435717#L268
```
/home/travis/build/ruby/psych/test/psych/visitors/test_yaml_tree.rb:10: warning: instance variable @obj not initialized
```

This is because `Psych.load` bypasses #initialize with the #init_with method.
