### PR TITLE
Get rid of C90 feature

### DIFF
--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -80,11 +80,12 @@ static VALUE allocate(VALUE klass)
 static VALUE make_exception(yaml_parser_t * parser, VALUE path)
 {
     size_t line, column;
+    VALUE ePsychSyntaxError;
 
     line = parser->context_mark.line + 1;
     column = parser->context_mark.column + 1;
 
-    VALUE ePsychSyntaxError = rb_const_get(mPsych, rb_intern("SyntaxError"));
+    ePsychSyntaxError = rb_const_get(mPsych, rb_intern("SyntaxError"));
 
     return rb_funcall(ePsychSyntaxError, rb_intern("new"), 6,
 	    path,


### PR DESCRIPTION
For ruby 2.6 and earlier.

https://travis-ci.org/ruby/psych/jobs/562435717#L245-L248

```
../../../../ext/psych/psych_parser.c: In function ‘make_exception’:
../../../../ext/psych/psych_parser.c:87:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
     VALUE ePsychSyntaxError = rb_const_get(mPsych, rb_intern("SyntaxError"));
     ^
```