### PR TITLE
Freeze parsing option

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -268,7 +268,7 @@ module Psych
   # YAML documents that are supplied via user input.  Instead, please use the
   # safe_load method.
   #
-  def self.load yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: false, symbolize_names: false
+  def self.load yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: false, symbolize_names: false, freeze: false
     if legacy_filename != NOT_GIVEN
       warn_with_uplevel 'Passing filename with the 2nd argument of Psych.load is deprecated. Use keyword argument like Psych.load(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
@@ -276,7 +276,7 @@ module Psych
 
     result = parse(yaml, filename: filename)
     return fallback unless result
-    result = result.to_ruby(symbolize_names: symbolize_names) if result
+    result = result.to_ruby(symbolize_names: symbolize_names, freeze: freeze) if result
     result
   end
 
@@ -324,7 +324,7 @@ module Psych
   #   Psych.safe_load("---\n foo: bar")                         # => {"foo"=>"bar"}
   #   Psych.safe_load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
-  def self.safe_load yaml, legacy_permitted_classes = NOT_GIVEN, legacy_permitted_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false
+  def self.safe_load yaml, legacy_permitted_classes = NOT_GIVEN, legacy_permitted_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false
     if legacy_permitted_classes != NOT_GIVEN
       warn_with_uplevel 'Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.', uplevel: 1 if $VERBOSE
       permitted_classes = legacy_permitted_classes
@@ -352,9 +352,9 @@ module Psych
                                                permitted_symbols.map(&:to_s))
     scanner      = ScalarScanner.new class_loader
     visitor = if aliases
-                Visitors::ToRuby.new scanner, class_loader, symbolize_names: symbolize_names
+                Visitors::ToRuby.new scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze
               else
-                Visitors::NoAliasRuby.new scanner, class_loader, symbolize_names: symbolize_names
+                Visitors::NoAliasRuby.new scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze
               end
     result = visitor.accept result
     result

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -46,8 +46,8 @@ module Psych
       # Convert this node to Ruby.
       #
       # See also Psych::Visitors::ToRuby
-      def to_ruby
-        Visitors::ToRuby.create.accept(self)
+      def to_ruby(symbolize_names: false)
+        Visitors::ToRuby.create(symbolize_names: symbolize_names).accept(self)
       end
       alias :transform :to_ruby
 

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -46,8 +46,8 @@ module Psych
       # Convert this node to Ruby.
       #
       # See also Psych::Visitors::ToRuby
-      def to_ruby(symbolize_names: false)
-        Visitors::ToRuby.create(symbolize_names: symbolize_names).accept(self)
+      def to_ruby(symbolize_names: false, freeze: false)
+        Visitors::ToRuby.create(symbolize_names: symbolize_names, freeze: freeze).accept(self)
       end
       alias :transform :to_ruby
 

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -12,21 +12,22 @@ module Psych
     ###
     # This class walks a YAML AST, converting each node to Ruby
     class ToRuby < Psych::Visitors::Visitor
-      def self.create(symbolize_names: false)
+      def self.create(symbolize_names: false, freeze: false)
         class_loader = ClassLoader.new
         scanner      = ScalarScanner.new class_loader
-        new(scanner, class_loader, symbolize_names: symbolize_names)
+        new(scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze)
       end
 
       attr_reader :class_loader
 
-      def initialize ss, class_loader, symbolize_names: false
+      def initialize ss, class_loader, symbolize_names: false, freeze: false
         super()
         @st = {}
         @ss = ss
         @domain_types = Psych.domain_types
         @class_loader = class_loader
         @symbolize_names = symbolize_names
+        @freeze = freeze
       end
 
       def accept target

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -192,6 +192,22 @@ class TestPsych < Psych::TestCase
     assert_equal({ 'hello' => 'world' }, got)
   end
 
+  def test_load_freeze
+    data = Psych.load("--- {foo: ['a']}", freeze: true)
+    assert_predicate data, :frozen?
+    assert_predicate data['foo'], :frozen?
+    assert_predicate data['foo'].first, :frozen?
+  end
+
+  def test_load_freeze_deduplication
+    unless String.method_defined?(:-@) && (-("a" * 20)).equal?((-("a" * 20)))
+      skip "This Ruby implementation doesn't support string deduplication"
+    end
+
+    data = Psych.load("--- ['a']", freeze: true)
+    assert_same 'a', data.first
+  end
+
   def test_load_default_fallback
     assert_equal false, Psych.load("")
   end


### PR DESCRIPTION
As discussed here: https://github.com/ruby/ruby/pull/2287#issuecomment-513865160
Followup: https://github.com/ruby/psych/pull/409

With this option enabled:

  - All the objects returned are frozen.
  - All string instances are deduplicated using `String#-@`.

Note that I had to first refactor `symbolize_names`, because it was mutating the data structures at the end of the parsing phase.

Also, we could go a bit further and deduplicate some specific objects such as empty hashes and arrays, but I opted to keep this PR as simple as possible.

@tenderlove @rafaelfranca @Edouard-chin