### PR TITLE
Set required_ruby_version to 2.4.0

### DIFF
--- a/psych.gemspec
+++ b/psych.gemspec
@@ -47,7 +47,7 @@ DESCRIPTION
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.2.2")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
   s.rubygems_version = "2.5.1"
   s.required_rubygems_version = Gem::Requirement.new(">= 0")
 


### PR DESCRIPTION
https://github.com/ruby/psych/pull/399 made the minimum usable version `2.4`.

I forgot to update the gemspec there.

@tenderlove @rafaelfranca @Edouard-chin