### PR TITLE
Raise exception on duplicate keys

### DIFF
--- a/lib/psych/handlers/document_stream.rb
+++ b/lib/psych/handlers/document_stream.rb
@@ -18,6 +18,18 @@ module Psych
         @last.implicit_end = implicit_end
         @block.call pop
       end
+
+      def end_mapping
+        mapping = pop
+        keys = {}
+        mapping.children.each_slice(2) do |(key_scalar, _)|
+          next if key_scalar.is_a?(Psych::Nodes::Sequence) or key_scalar.is_a?(Psych::Nodes::Alias) or key_scalar.is_a?(Psych::Nodes::Mapping)
+          key = key_scalar.value
+          raise Psych::Exception, "Duplicate key #{key} exists on this level" if keys.key? key
+          keys[key] = nil
+        end
+        mapping
+      end
     end
   end
 end

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -92,6 +92,16 @@ module Psych
       assert_equal X, x.class
     end
 
+    def test_error_on_same_key
+      assert_raises(Psych::Exception) do
+        Psych.load <<-EOF
+        -
+          same_key: 'value'
+          same_key: 'value'
+        EOF
+      end
+    end
+
     def test_self_referential
       @hash['self'] = @hash
       assert_cycle(@hash)


### PR DESCRIPTION
The [YAML spec](https://yaml.org/spec/1.1/#id859497) is extremely clear that duplicate keys are forbidden. A few examples:

> an unordered association of unique keys to values

and:

> keys are unordered and must be unique

and:

> The content of a mapping node is an unordered set of key: value node pairs, with the restriction that each of the keys is unique

and:

> YAML mappings require key uniqueness

For these reasons, psych should raise an exception when trying to parse YAML with duplicate keys. It should be considered a bug that this ever worked, so I don't think we need to worry about backwards compatibility to support out-of-spec YAML parsing.

This PR adds functionality to raise an exception on duplicates, and a test for it. Closes #79.