### PR TITLE
Remove unnecessary check on version

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 module Psych
   # The version of Psych you are using
-  VERSION = '3.1.0' unless defined?(::Psych::VERSION)
+  VERSION = '3.1.0'
 
   if RUBY_ENGINE == 'jruby'
     DEFAULT_SNAKEYAML_VERSION = '1.23'.freeze

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -1,12 +1,10 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
-begin
-  require_relative 'lib/psych/versions'
-rescue LoadError
-  # for Ruby core repository
-  require_relative 'versions'
-end
+lib_path = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift lib_path if File.exist?(lib_path)
+
+require 'psych/versions'
 
 Gem::Specification.new do |s|
   s.name = "psych"


### PR DESCRIPTION
I had a look at the warnings being fixed in #390 to try to come up with a better solution.

Initially, I was able to reproduce the issue by running `bundle` from the root of this repo. The issue happened because my jruby installation had a `psych` installation at: `~/.rbenv/versions/jruby-9.2.9.0/lib/ruby/gems/shared/gems`, and that specific installation _did not_ have the version guard in `versions.rb` that this repository included. So, when running `bundle` first the local gemspec would be loaded which loads the versions.rb file in the repository relatively, then `bundler` would load the "system" version of psych _without_ the version guard, causing the redefinition warnings.

The changes in this PR fix the issue because the local version of `psych` is always loaded.

However, I cannot reproduce on a pristine installation of jruby, because `psych` is not included in the `~/.rbenv/versions/jruby-9.2.9.0/lib/ruby/gems/shared/gems`, so now I'm not sure how to reproduce this anymore... :/