### PR TITLE
Fix ArgumentError with leading and trailing underscores in number str…

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -101,7 +101,7 @@ module Psych
     ###
     # Parse and return an int from +string+
     def parse_int string
-      Integer(string.gsub(/[,]/, ''))
+      Integer(string.gsub(/[,_]/, ''))
     end
 
     ###

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -120,6 +120,7 @@ module Psych
       assert_equal 123_456_789, ss.tokenize('123_456_789')
       assert_equal 123_456_789, ss.tokenize('123,456,789')
       assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789')
+      assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789_')
 
       assert_equal 0b010101010, ss.tokenize('0b010101010')
       assert_equal 0b010101010, ss.tokenize('0b0,1_0,1_,0,1_01,0')
@@ -129,6 +130,8 @@ module Psych
 
       assert_equal 0x123456789abcdef, ss.tokenize('0x123456789abcdef')
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef')
+      assert_equal 0x123456789abcdef, ss.tokenize('0x_12_,34,_56,_789abcdef')
+      assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef__')
     end
   end
 end


### PR DESCRIPTION
…ings.

001:0> require 'psych'
true
002:0> '123_'.to_yaml
Traceback (most recent call last):
        ...
        4: from .../lib/ruby/2.7.0/psych/visitors/yaml_tree.rb:279:in `visit_String'
        3: from .../lib/ruby/2.7.0/psych/scalar_scanner.rb:95:in `tokenize'
        2: from .../lib/ruby/2.7.0/psych/scalar_scanner.rb:104:in `parse_int'
        1: from .../lib/ruby/2.7.0/psych/scalar_scanner.rb:104:in `Integer'
ArgumentError (invalid value for Integer(): "123_")
003:0> '0x_123'.to_yaml
Traceback (most recent call last):
        ...
        4: from .../lib/ruby/2.7.0/psych/visitors/yaml_tree.rb:279:in `visit_String'
        3: from .../lib/ruby/2.7.0/psych/scalar_scanner.rb:95:in `tokenize'
        2: from .../lib/ruby/2.7.0/psych/scalar_scanner.rb:104:in `parse_int'
        1: from .../lib/ruby/2.7.0/psych/scalar_scanner.rb:104:in `Integer'
ArgumentError (invalid value for Integer(): "0x_123")

