### PR TITLE
Handle trailing underscores in integers

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -101,7 +101,7 @@ module Psych
     ###
     # Parse and return an int from +string+
     def parse_int string
-      Integer(string.gsub(/[,]/, ''))
+      Integer(string.gsub(/[,_]/, ''))
     end
 
     ###

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -129,6 +129,8 @@ module Psych
 
       assert_equal 0x123456789abcdef, ss.tokenize('0x123456789abcdef')
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef')
+
+      assert_equal 11, ss.tokenize('1____________1_________')
     end
   end
 end


### PR DESCRIPTION
Fix: #442 
Ref: https://github.com/ruby/psych/pull/400

That regression was introduced in https://github.com/ruby/psych/commit/7d04834b79aa6677b1bff42161311cb79809ed7d

I incorrectly assumed that trailing underscores were handled by `Integer`, while they're not.

```
>> RUBY_VERSION
=> "2.6.3"
>> YAML.load('1_')
=> 1
```

vs

```
>> RUBY_VERSION
=> "2.7.1"
>> YAML.load('1_')
Traceback (most recent call last):
       16: from /Users/byroot/.gem/ruby/2.7.1/gems/irb-1.2.3/exe/irb:11:in `<top (required)>'
       15: from (irb):3
       14: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych.rb:279:in `load'
       13: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/nodes/node.rb:50:in `to_ruby'
       12: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/to_ruby.rb:32:in `accept'
       11: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/visitor.rb:6:in `accept'
       10: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/visitor.rb:16:in `visit'
        9: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/to_ruby.rb:313:in `visit_Psych_Nodes_Document'
        8: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/to_ruby.rb:32:in `accept'
        7: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/visitor.rb:6:in `accept'
        6: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/visitor.rb:16:in `visit'
        5: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/to_ruby.rb:123:in `visit_Psych_Nodes_Scalar'
        4: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/visitors/to_ruby.rb:60:in `deserialize'
        3: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/scalar_scanner.rb:95:in `tokenize'
        2: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/scalar_scanner.rb:104:in `parse_int'
        1: from /opt/rubies/2.7.1/lib/ruby/2.7.0/psych/scalar_scanner.rb:104:in `Integer'
ArgumentError (invalid value for Integer(): "1_")
```

cc @hsbt @tenderlove 

Also for anyone having issues caused by this regression, the following monkey patch can unblock you:

```ruby
require 'psych'

module PsychIntegerParsingPatch
  def parse_int string
    Integer(string.gsub(/[,_]/, ''))
  end
end

Psych::ScalarScanner.prepend(PsychIntegerParsingPatch)
```