### PR TITLE
Make 'y' & 'n' into booleans (true/false)

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -41,9 +41,9 @@ module Psych
           string
         elsif string == '~' || string.match?(/^null$/i)
           nil
-        elsif string.match?(/^(yes|true|on)$/i)
+        elsif string.match?(/^(y|yes|true|on)$/i)
           true
-        elsif string.match?(/^(no|false|off)$/i)
+        elsif string.match?(/^(n|no|false|off)$/i)
           false
         else
           string

--- a/test/psych/test_boolean.rb
+++ b/test/psych/test_boolean.rb
@@ -6,32 +6,44 @@ module Psych
   # Test booleans from YAML spec:
   # http://yaml.org/type/bool.html
   class TestBoolean < TestCase
-    %w{ yes Yes YES true True TRUE on On ON }.each do |truth|
+    %w{ y Y yes Yes YES true True TRUE on On ON }.each do |truth|
       define_method(:"test_#{truth}") do
         assert_equal true, Psych.load("--- #{truth}")
       end
     end
 
-    %w{ no No NO false False FALSE off Off OFF }.each do |truth|
+    %w{ n N no No NO false False FALSE off Off OFF }.each do |truth|
       define_method(:"test_#{truth}") do
         assert_equal false, Psych.load("--- #{truth}")
       end
     end
 
     ###
-    # YAML spec says "y" and "Y" may be used as true, but Syck treats them
-    # as literal strings
-    def test_y
-      assert_equal "y", Psych.load("--- y")
-      assert_equal "Y", Psych.load("--- Y")
+    # A quoted 'y' string should load as a string (not +true+).
+    # A 'y' string should dump a quoted string (not +true+).
+    # A non-quoted +y+ should load/dump as +true+.
+    #
+    # This is incompatible with Ruby's original Syck library,
+    # but compatible with YAML spec v1.1.
+    def test_y_str
+      assert_equal "y", Psych.load("--- 'y'")
+      assert_equal "Y", Psych.load("--- 'Y'")
+      assert_equal "--- 'y'\n", Psych.dump('y')
+      assert_equal "--- 'Y'\n", Psych.dump('Y')
     end
 
     ###
-    # YAML spec says "n" and "N" may be used as false, but Syck treats them
-    # as literal strings
-    def test_n
-      assert_equal "n", Psych.load("--- n")
-      assert_equal "N", Psych.load("--- N")
+    # A quoted 'n' string should load as a string (not +false+).
+    # An 'n' string should dump a quoted string (not +false+).
+    # A non-quoted +n+ should load/dump as +false+.
+    #
+    # This is incompatible with Ruby's original Syck library,
+    # but compatible with YAML spec v1.1.
+    def test_n_str
+      assert_equal "n", Psych.load("--- 'n'")
+      assert_equal "N", Psych.load("--- 'N'")
+      assert_equal "--- 'n'\n", Psych.dump('n')
+      assert_equal "--- 'N'\n", Psych.dump('N')
     end
   end
 end

--- a/test/psych/test_merge_keys.rb
+++ b/test/psych/test_merge_keys.rb
@@ -130,8 +130,8 @@ bar:
     def test_multiple_maps
       yaml = <<-eoyaml
 ---
-- &CENTER { x: 1, y: 2 }
-- &LEFT { x: 0, y: 2 }
+- &CENTER { x: 1, 'y': 2 }
+- &LEFT { x: 0, 'y': 2 }
 - &BIG { r: 10 }
 - &SMALL { r: 1 }
 
@@ -155,8 +155,8 @@ bar:
     def test_override
       yaml = <<-eoyaml
 ---
-- &CENTER { x: 1, y: 2 }
-- &LEFT { x: 0, y: 2 }
+- &CENTER { x: 1, 'y': 2 }
+- &LEFT { x: 0, 'y': 2 }
 - &BIG { r: 10 }
 - &SMALL { r: 1 }
 

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -751,11 +751,11 @@ EOY
 			[[{"radius"=>7, "center"=>{"x"=>73, "y"=>129}, "TYPE"=>"Shape: graph/circle"}, {"finish"=>{"x"=>89, "y"=>102}, "TYPE"=>"Shape: graph/line", "start"=>{"x"=>73, "y"=>129}}, {"TYPE"=>"Shape: graph/text", "value"=>"Pretty vector drawing.", "start"=>{"x"=>73, "y"=>129}, "color"=>16772795}, "Shape Container"]], <<EOY
 - !clarkevans.com,2002/graph/shape
   - !/graph/circle
-    center: &ORIGIN {x: 73, y: 129}
+    center: &ORIGIN {x: 73, 'y': 129}
     radius: 7
   - !/graph/line # !clarkevans.com,2002/graph/line
     start: *ORIGIN
-    finish: { x: 89, y: 102 }
+    finish: { x: 89, 'y': 102 }
   - !/graph/text
     start: *ORIGIN
     color: 0xFFEEBB

--- a/test/psych/test_yaml_special_cases.rb
+++ b/test/psych/test_yaml_special_cases.rb
@@ -29,8 +29,35 @@ module Psych
       assert_equal false, Psych.safe_load(s)
     end
 
+    def test_y
+      s = "y"
+      assert_equal true, Psych.load(s)
+      assert_equal [true], Psych.load_stream(s)
+      assert_equal true, Psych.parse(s).transform
+      assert_equal [true], Psych.parse_stream(s).transform
+      assert_equal true, Psych.safe_load(s)
+    end
+
+    def test_y_str
+      s = "'y'"
+      assert_equal "y", Psych.load(s)
+      assert_equal ["y"], Psych.load_stream(s)
+      assert_equal "y", Psych.parse(s).transform
+      assert_equal ["y"], Psych.parse_stream(s).transform
+      assert_equal "y", Psych.safe_load(s)
+    end
+
     def test_n
       s = "n"
+      assert_equal false, Psych.load(s)
+      assert_equal [false], Psych.load_stream(s)
+      assert_equal false, Psych.parse(s).transform
+      assert_equal [false], Psych.parse_stream(s).transform
+      assert_equal false, Psych.safe_load(s)
+    end
+
+    def test_n_str
+      s = "'n'"
       assert_equal "n", Psych.load(s)
       assert_equal ["n"], Psych.load_stream(s)
       assert_equal "n", Psych.parse(s).transform

--- a/test/psych/visitors/test_to_ruby.rb
+++ b/test/psych/visitors/test_to_ruby.rb
@@ -223,7 +223,7 @@ description:
 
       # http://yaml.org/type/bool.html
       def test_boolean_true
-        %w{ yes Yes YES true True TRUE on On ON }.each do |t|
+        %w{ y Y yes Yes YES true True TRUE on On ON }.each do |t|
           i = Nodes::Scalar.new(t, nil, 'tag:yaml.org,2002:bool')
           assert_equal true, i.to_ruby
           assert_equal true, Nodes::Scalar.new(t).to_ruby
@@ -232,7 +232,7 @@ description:
 
       # http://yaml.org/type/bool.html
       def test_boolean_false
-        %w{ no No NO false False FALSE off Off OFF }.each do |t|
+        %w{ n N no No NO false False FALSE off Off OFF }.each do |t|
           i = Nodes::Scalar.new(t, nil, 'tag:yaml.org,2002:bool')
           assert_equal false, i.to_ruby
           assert_equal false, Nodes::Scalar.new(t).to_ruby


### PR DESCRIPTION
Issue #443

In order to be compatible with Ruby's original Syck library, Psych made y/n default to strings. However, now, the Syck library is dead, and I think it makes since to make Psych compliant with YAML spec v1.1.

In the issue, this caused a problem when Psych produced a non-compliant file that then broke in a compliant parser in another language. I think it's important that Psych makes YAML files that can be consumed by anything that speaks YAML.

[https://yaml.org/type/bool.html](https://yaml.org/type/bool.html)

However, this is a potentially breaking change. If previous gems relied on y/n as strings, they will now need to be updated to use single/double quotes. This is rare, but should be considered, especially for YAML common as this:

```YAML
MySprite:
  x: 100
  y: 100
  z: 1
```

It will need to be updated to this:

```YAML
MySprite:
  x: 100
  'y': 100
  z: 1
```

Maybe this should be a major version change? However, these gems relied on a broken/non-compliant parser, so it's a difficult decision to make.

Instead of this solution, we could...
- add some type of `strict_compliance` keyword arg option,
- or, output a deprecated warning to users for a couple of versions to update their YAML files.