### PR TITLE
Fix anchor lookup with symbolized names

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -337,18 +337,12 @@ module Psych
         list
       end
 
-      SHOVEL = '<<'
       def revive_hash hash, o
         o.children.each_slice(2) { |k,v|
           key = accept(k)
-          if @symbolize_names
-            key = key.to_sym
-          elsif !@freeze
-            key = deduplicate(key)
-          end
           val = accept(v)
 
-          if key == SHOVEL && k.tag != "tag:yaml.org,2002:str"
+          if key == '<<' && k.tag != "tag:yaml.org,2002:str"
             case v
             when Nodes::Alias, Nodes::Mapping
               begin
@@ -370,6 +364,12 @@ module Psych
               hash[key] = val
             end
           else
+            if @symbolize_names
+              key = key.to_sym
+            elsif !@freeze
+              key = deduplicate(key)
+            end
+
             hash[key] = val
           end
 

--- a/test/psych/test_merge_keys.rb
+++ b/test/psych/test_merge_keys.rb
@@ -17,6 +17,16 @@ map:
       assert_equal hash, doc
     end
 
+    def test_merge_key_with_bare_hash_symbolized_names
+      doc = Psych.load <<-eodoc, symbolize_names: true
+map:
+  <<:
+    hello: world
+      eodoc
+      hash = { map: { hello: "world" } }
+      assert_equal hash, doc
+    end
+
     def test_roundtrip_with_chevron_key
       h = {}
       v = { 'a' => h, '<<' => h }


### PR DESCRIPTION
While testing ruby-head I discovered this regression introduced by myself in https://github.com/ruby/psych/pull/414

`'<<'` was being converted to a symbol `:<<` which caused the `if key == SHOVEL` test to never pass.

@tenderlove 