### PR TITLE
Bump libyaml version to 0.2.5

### DIFF
--- a/ext/psych/yaml/api.c
+++ b/ext/psych/yaml/api.c
@@ -118,7 +118,12 @@ yaml_string_join(
 YAML_DECLARE(int)
 yaml_stack_extend(void **start, void **top, void **end)
 {
-    void *new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
+    void *new_start;
+
+    if ((char *)*end - (char *)*start >= INT_MAX / 2)
+	return 0;
+
+    new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
 
     if (!new_start) return 0;
 
@@ -618,10 +623,10 @@ yaml_token_delete(yaml_token_t *token)
  */
 
 static int
-yaml_check_utf8(yaml_char_t *start, size_t length)
+yaml_check_utf8(const yaml_char_t *start, size_t length)
 {
-    yaml_char_t *end = start+length;
-    yaml_char_t *pointer = start;
+    const yaml_char_t *end = start+length;
+    const yaml_char_t *pointer = start;
 
     while (pointer < end) {
         unsigned char octet;
@@ -789,7 +794,7 @@ yaml_document_end_event_initialize(yaml_event_t *event, int implicit)
  */
 
 YAML_DECLARE(int)
-yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor)
+yaml_alias_event_initialize(yaml_event_t *event, const yaml_char_t *anchor)
 {
     yaml_mark_t mark = { 0, 0, 0 };
     yaml_char_t *anchor_copy = NULL;
@@ -814,8 +819,8 @@ yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor)
 
 YAML_DECLARE(int)
 yaml_scalar_event_initialize(yaml_event_t *event,
-        yaml_char_t *anchor, yaml_char_t *tag,
-        yaml_char_t *value, int length,
+        const yaml_char_t *anchor, const yaml_char_t *tag,
+        const yaml_char_t *value, int length,
         int plain_implicit, int quoted_implicit,
         yaml_scalar_style_t style)
 {
@@ -868,7 +873,7 @@ error:
 
 YAML_DECLARE(int)
 yaml_sequence_start_event_initialize(yaml_event_t *event,
-        yaml_char_t *anchor, yaml_char_t *tag, int implicit,
+        const yaml_char_t *anchor, const yaml_char_t *tag, int implicit,
         yaml_sequence_style_t style)
 {
     yaml_mark_t mark = { 0, 0, 0 };
@@ -923,7 +928,7 @@ yaml_sequence_end_event_initialize(yaml_event_t *event)
 
 YAML_DECLARE(int)
 yaml_mapping_start_event_initialize(yaml_event_t *event,
-        yaml_char_t *anchor, yaml_char_t *tag, int implicit,
+        const yaml_char_t *anchor, const yaml_char_t *tag, int implicit,
         yaml_mapping_style_t style)
 {
     yaml_mark_t mark = { 0, 0, 0 };
@@ -1117,14 +1122,7 @@ error:
 YAML_DECLARE(void)
 yaml_document_delete(yaml_document_t *document)
 {
-    struct {
-        yaml_error_type_t error;
-    } context;
     yaml_tag_directive_t *tag_directive;
-
-    /* Eliminate a compliler warning. */
-    context.error = YAML_NO_ERROR;
-    (void)context.error;
 
     assert(document);   /* Non-NULL document object is expected. */
 
@@ -1195,7 +1193,7 @@ yaml_document_get_root_node(yaml_document_t *document)
 
 YAML_DECLARE(int)
 yaml_document_add_scalar(yaml_document_t *document,
-        yaml_char_t *tag, yaml_char_t *value, int length,
+        const yaml_char_t *tag, const yaml_char_t *value, int length,
         yaml_scalar_style_t style)
 {
     struct {
@@ -1245,7 +1243,7 @@ error:
 
 YAML_DECLARE(int)
 yaml_document_add_sequence(yaml_document_t *document,
-        yaml_char_t *tag, yaml_sequence_style_t style)
+        const yaml_char_t *tag, yaml_sequence_style_t style)
 {
     struct {
         yaml_error_type_t error;
@@ -1290,7 +1288,7 @@ error:
 
 YAML_DECLARE(int)
 yaml_document_add_mapping(yaml_document_t *document,
-        yaml_char_t *tag, yaml_mapping_style_t style)
+        const yaml_char_t *tag, yaml_mapping_style_t style)
 {
     struct {
         yaml_error_type_t error;

--- a/ext/psych/yaml/config.h
+++ b/ext/psych/yaml/config.h
@@ -44,7 +44,7 @@
 #define PACKAGE_NAME "yaml"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "yaml 0.2.1"
+#define PACKAGE_STRING "yaml 0.2.5"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "yaml"
@@ -53,13 +53,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.2.1"
+#define PACKAGE_VERSION "0.2.5"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "0.2.1"
+#define VERSION "0.2.5"
 
 /* Define the major version number. */
 #define YAML_VERSION_MAJOR 0
@@ -68,10 +68,10 @@
 #define YAML_VERSION_MINOR 2
 
 /* Define the patch version number. */
-#define YAML_VERSION_PATCH 1
+#define YAML_VERSION_PATCH 5
 
 /* Define the version string. */
-#define YAML_VERSION_STRING "0.2.1"
+#define YAML_VERSION_STRING "0.2.5"
 
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/ext/psych/yaml/config.h
+++ b/ext/psych/yaml/config.h
@@ -1,10 +1,80 @@
+/* include/config.h.  Generated from config.h.in by configure.  */
+/* include/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "yaml"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://github.com/yaml/libyaml/issues/new"
+
+/* Define to the full name of this package. */
 #define PACKAGE_NAME "yaml"
-#define PACKAGE_TARNAME "yaml"
-#define PACKAGE_VERSION "0.2.1"
+
+/* Define to the full name and version of this package. */
 #define PACKAGE_STRING "yaml 0.2.1"
-#define PACKAGE_BUGREPORT "https://github.com/yaml/libyaml/issues"
-#define PACKAGE_URL "https://github.com/yaml/libyaml"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "yaml"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.2.1"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "0.2.1"
+
+/* Define the major version number. */
 #define YAML_VERSION_MAJOR 0
+
+/* Define the minor version number. */
 #define YAML_VERSION_MINOR 2
+
+/* Define the patch version number. */
 #define YAML_VERSION_PATCH 1
+
+/* Define the version string. */
 #define YAML_VERSION_STRING "0.2.1"
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */

--- a/ext/psych/yaml/dumper.c
+++ b/ext/psych/yaml/dumper.c
@@ -131,7 +131,7 @@ yaml_emitter_dump(yaml_emitter_t *emitter, yaml_document_t *document)
 
     assert(emitter->opened);    /* Emitter should be opened. */
 
-    emitter->anchors = yaml_malloc(sizeof(*(emitter->anchors))
+    emitter->anchors = (yaml_anchors_t*)yaml_malloc(sizeof(*(emitter->anchors))
             * (document->nodes.top - document->nodes.start));
     if (!emitter->anchors) goto error;
     memset(emitter->anchors, 0, sizeof(*(emitter->anchors))

--- a/ext/psych/yaml/emitter.c
+++ b/ext/psych/yaml/emitter.c
@@ -16,7 +16,7 @@
 #define PUT(emitter,value)                                                      \
     (FLUSH(emitter)                                                             \
      && (*(emitter->buffer.pointer++) = (yaml_char_t)(value),                   \
-         emitter->column ++,                                                    \
+         emitter->column++,                                             	\
          1))
 
 /*
@@ -495,6 +495,7 @@ static int
 yaml_emitter_emit_stream_start(yaml_emitter_t *emitter,
         yaml_event_t *event)
 {
+    emitter->open_ended = 0;
     if (event->type == YAML_STREAM_START_EVENT)
     {
         if (!emitter->encoding) {
@@ -597,13 +598,20 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
+        emitter->open_ended = 0;
 
         if (event->data.document_start.version_directive) {
             implicit = 0;
             if (!yaml_emitter_write_indicator(emitter, "%YAML", 1, 0, 0))
                 return 0;
-            if (!yaml_emitter_write_indicator(emitter, "1.1", 1, 0, 0))
-                return 0;
+            if (event->data.document_start.version_directive->minor == 1) {
+                if (!yaml_emitter_write_indicator(emitter, "1.1", 1, 0, 0))
+                    return 0;
+            }
+            else {
+                if (!yaml_emitter_write_indicator(emitter, "1.2", 1, 0, 0))
+                    return 0;
+            }
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
@@ -644,19 +652,25 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
 
         emitter->state = YAML_EMIT_DOCUMENT_CONTENT_STATE;
 
+        emitter->open_ended = 0;
         return 1;
     }
 
     else if (event->type == YAML_STREAM_END_EVENT)
     {
-        if (emitter->open_ended)
+
+        /**
+         * This can happen if a block scalar with trailing empty lines
+         * is at the end of the stream
+         */
+        if (emitter->open_ended == 2)
         {
             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
                 return 0;
+            emitter->open_ended = 0;
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
-
         if (!yaml_emitter_flush(emitter))
             return 0;
 
@@ -698,9 +712,12 @@ yaml_emitter_emit_document_end(yaml_emitter_t *emitter,
         if (!event->data.document_end.implicit) {
             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
                 return 0;
+            emitter->open_ended = 0;
             if (!yaml_emitter_write_indent(emitter))
                 return 0;
         }
+        else if (!emitter->open_ended)
+            emitter->open_ended = 1;
         if (!yaml_emitter_flush(emitter))
             return 0;
 
@@ -1006,6 +1023,8 @@ yaml_emitter_emit_alias(yaml_emitter_t *emitter, SHIM(yaml_event_t *event))
 {
     if (!yaml_emitter_process_anchor(emitter))
         return 0;
+    if (emitter->simple_key_context)
+        if (!PUT(emitter, ' ')) return 0;
     emitter->state = POP(emitter, emitter->states);
 
     return 1;
@@ -1333,7 +1352,10 @@ static int
 yaml_emitter_analyze_version_directive(yaml_emitter_t *emitter,
         yaml_version_directive_t version_directive)
 {
-    if (version_directive.major != 1 || version_directive.minor != 1) {
+    if (version_directive.major != 1 || (
+        version_directive.minor != 1
+        && version_directive.minor != 2
+        )) {
         return yaml_emitter_set_emitter_error(emitter,
                 "incompatible %YAML directive");
     }
@@ -1803,7 +1825,6 @@ yaml_emitter_write_indicator(yaml_emitter_t *emitter,
 
     emitter->whitespace = is_whitespace;
     emitter->indention = (emitter->indention && is_indention);
-    emitter->open_ended = 0;
 
     return 1;
 }
@@ -1904,7 +1925,17 @@ yaml_emitter_write_plain_scalar(yaml_emitter_t *emitter,
 
     STRING_ASSIGN(string, value, length);
 
-    if (!emitter->whitespace) {
+    /**
+     * Avoid trailing spaces for empty values in block mode.
+     * In flow mode, we still want the space to prevent ambiguous things
+     * like {a:}.
+     * Currently, the emitter forbids any plain empty scalar in flow mode
+     * (e.g. it outputs {a: ''} instead), so emitter->flow_level will
+     * never be true here.
+     * But if the emitter is ever changed to allow emitting empty values,
+     * the check for flow_level is already here.
+     */
+    if (!emitter->whitespace && (length || emitter->flow_level)) {
         if (!PUT(emitter, ' ')) return 0;
     }
 
@@ -2003,6 +2034,9 @@ yaml_emitter_write_single_quoted_scalar(yaml_emitter_t *emitter,
             breaks = 0;
         }
     }
+
+    if (breaks)
+        if (!yaml_emitter_write_indent(emitter)) return 0;
 
     if (!yaml_emitter_write_indicator(emitter, "'", 0, 0, 0))
         return 0;
@@ -2203,7 +2237,7 @@ yaml_emitter_write_block_scalar_hints(yaml_emitter_t *emitter,
         else if (string.start == string.pointer)
         {
             chomp_hint = "+";
-            emitter->open_ended = 1;
+            emitter->open_ended = 2;
         }
         else
         {
@@ -2213,7 +2247,7 @@ yaml_emitter_write_block_scalar_hints(yaml_emitter_t *emitter,
             if (IS_BREAK(string))
             {
                 chomp_hint = "+";
-                emitter->open_ended = 1;
+                emitter->open_ended = 2;
             }
         }
     }

--- a/ext/psych/yaml/loader.c
+++ b/ext/psych/yaml/loader.c
@@ -38,26 +38,46 @@ static void
 yaml_parser_delete_aliases(yaml_parser_t *parser);
 
 /*
+ * Document loading context.
+ */
+struct loader_ctx {
+    int *start;
+    int *end;
+    int *top;
+};
+
+/*
  * Composer functions.
  */
+static int
+yaml_parser_load_nodes(yaml_parser_t *parser, struct loader_ctx *ctx);
 
 static int
-yaml_parser_load_document(yaml_parser_t *parser, yaml_event_t *first_event);
+yaml_parser_load_document(yaml_parser_t *parser, yaml_event_t *event);
 
 static int
-yaml_parser_load_node(yaml_parser_t *parser, yaml_event_t *first_event);
+yaml_parser_load_alias(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx);
 
 static int
-yaml_parser_load_alias(yaml_parser_t *parser, yaml_event_t *first_event);
+yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx);
 
 static int
-yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *first_event);
+yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx);
 
 static int
-yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event);
+yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx);
 
 static int
-yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event);
+yaml_parser_load_sequence_end(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx);
+
+static int
+yaml_parser_load_mapping_end(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx);
 
 /*
  * Load the next document of the stream.
@@ -162,59 +182,78 @@ yaml_parser_delete_aliases(yaml_parser_t *parser)
  */
 
 static int
-yaml_parser_load_document(yaml_parser_t *parser, yaml_event_t *first_event)
+yaml_parser_load_document(yaml_parser_t *parser, yaml_event_t *event)
 {
-    yaml_event_t event;
+    struct loader_ctx ctx = { NULL, NULL, NULL };
 
-    assert(first_event->type == YAML_DOCUMENT_START_EVENT);
+    assert(event->type == YAML_DOCUMENT_START_EVENT);
                         /* DOCUMENT-START is expected. */
 
     parser->document->version_directive
-        = first_event->data.document_start.version_directive;
+        = event->data.document_start.version_directive;
     parser->document->tag_directives.start
-        = first_event->data.document_start.tag_directives.start;
+        = event->data.document_start.tag_directives.start;
     parser->document->tag_directives.end
-        = first_event->data.document_start.tag_directives.end;
+        = event->data.document_start.tag_directives.end;
     parser->document->start_implicit
-        = first_event->data.document_start.implicit;
-    parser->document->start_mark = first_event->start_mark;
+        = event->data.document_start.implicit;
+    parser->document->start_mark = event->start_mark;
 
-    if (!yaml_parser_parse(parser, &event)) return 0;
-
-    if (!yaml_parser_load_node(parser, &event)) return 0;
-
-    if (!yaml_parser_parse(parser, &event)) return 0;
-    assert(event.type == YAML_DOCUMENT_END_EVENT);
-                        /* DOCUMENT-END is expected. */
-
-    parser->document->end_implicit = event.data.document_end.implicit;
-    parser->document->end_mark = event.end_mark;
+    if (!STACK_INIT(parser, ctx, int*)) return 0;
+    if (!yaml_parser_load_nodes(parser, &ctx)) {
+        STACK_DEL(parser, ctx);
+        return 0;
+    }
+    STACK_DEL(parser, ctx);
 
     return 1;
 }
 
 /*
- * Compose a node.
+ * Compose a node tree.
  */
 
 static int
-yaml_parser_load_node(yaml_parser_t *parser, yaml_event_t *first_event)
+yaml_parser_load_nodes(yaml_parser_t *parser, struct loader_ctx *ctx)
 {
-    switch (first_event->type) {
-        case YAML_ALIAS_EVENT:
-            return yaml_parser_load_alias(parser, first_event);
-        case YAML_SCALAR_EVENT:
-            return yaml_parser_load_scalar(parser, first_event);
-        case YAML_SEQUENCE_START_EVENT:
-            return yaml_parser_load_sequence(parser, first_event);
-        case YAML_MAPPING_START_EVENT:
-            return yaml_parser_load_mapping(parser, first_event);
-        default:
-            assert(0);  /* Could not happen. */
-            return 0;
-    }
+    yaml_event_t event;
 
-    return 0;
+    do {
+        if (!yaml_parser_parse(parser, &event)) return 0;
+
+        switch (event.type) {
+            case YAML_ALIAS_EVENT:
+                if (!yaml_parser_load_alias(parser, &event, ctx)) return 0;
+                break;
+            case YAML_SCALAR_EVENT:
+                if (!yaml_parser_load_scalar(parser, &event, ctx)) return 0;
+                break;
+            case YAML_SEQUENCE_START_EVENT:
+                if (!yaml_parser_load_sequence(parser, &event, ctx)) return 0;
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                if (!yaml_parser_load_sequence_end(parser, &event, ctx))
+                    return 0;
+                break;
+            case YAML_MAPPING_START_EVENT:
+                if (!yaml_parser_load_mapping(parser, &event, ctx)) return 0;
+                break;
+            case YAML_MAPPING_END_EVENT:
+                if (!yaml_parser_load_mapping_end(parser, &event, ctx))
+                    return 0;
+                break;
+            default:
+                assert(0);  /* Could not happen. */
+                return 0;
+            case YAML_DOCUMENT_END_EVENT:
+                break;
+        }
+    } while (event.type != YAML_DOCUMENT_END_EVENT);
+
+    parser->document->end_implicit = event.data.document_end.implicit;
+    parser->document->end_mark = event.end_mark;
+
+    return 1;
 }
 
 /*
@@ -253,26 +292,79 @@ yaml_parser_register_anchor(yaml_parser_t *parser,
 }
 
 /*
+ * Compose node into its parent in the stree.
+ */
+
+static int
+yaml_parser_load_node_add(yaml_parser_t *parser, struct loader_ctx *ctx,
+        int index)
+{
+    struct yaml_node_s *parent;
+    int parent_index;
+
+    if (STACK_EMPTY(parser, *ctx)) {
+        /* This is the root node, there's no tree to add it to. */
+        return 1;
+    }
+
+    parent_index = *((*ctx).top - 1);
+    parent = &parser->document->nodes.start[parent_index-1];
+
+    switch (parent->type) {
+        case YAML_SEQUENCE_NODE:
+            if (!STACK_LIMIT(parser, parent->data.sequence.items, INT_MAX-1))
+                return 0;
+            if (!PUSH(parser, parent->data.sequence.items, index))
+                return 0;
+            break;
+        case YAML_MAPPING_NODE: {
+            yaml_node_pair_t pair;
+            if (!STACK_EMPTY(parser, parent->data.mapping.pairs)) {
+                yaml_node_pair_t *p = parent->data.mapping.pairs.top - 1;
+                if (p->key != 0 && p->value == 0) {
+                    p->value = index;
+                    break;
+                }
+            }
+
+            pair.key = index;
+            pair.value = 0;
+            if (!STACK_LIMIT(parser, parent->data.mapping.pairs, INT_MAX-1))
+                return 0;
+            if (!PUSH(parser, parent->data.mapping.pairs, pair))
+                return 0;
+
+            break;
+        }
+        default:
+            assert(0); /* Could not happen. */
+            return 0;
+    }
+    return 1;
+}
+
+/*
  * Compose a node corresponding to an alias.
  */
 
 static int
-yaml_parser_load_alias(yaml_parser_t *parser, yaml_event_t *first_event)
+yaml_parser_load_alias(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx)
 {
-    yaml_char_t *anchor = first_event->data.alias.anchor;
+    yaml_char_t *anchor = event->data.alias.anchor;
     yaml_alias_data_t *alias_data;
 
     for (alias_data = parser->aliases.start;
             alias_data != parser->aliases.top; alias_data ++) {
         if (strcmp((char *)alias_data->anchor, (char *)anchor) == 0) {
             yaml_free(anchor);
-            return alias_data->index;
+            return yaml_parser_load_node_add(parser, ctx, alias_data->index);
         }
     }
 
     yaml_free(anchor);
     return yaml_parser_set_composer_error(parser, "found undefined alias",
-            first_event->start_mark);
+            event->start_mark);
 }
 
 /*
@@ -280,11 +372,12 @@ yaml_parser_load_alias(yaml_parser_t *parser, yaml_event_t *first_event)
  */
 
 static int
-yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *first_event)
+yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx)
 {
     yaml_node_t node;
     int index;
-    yaml_char_t *tag = first_event->data.scalar.tag;
+    yaml_char_t *tag = event->data.scalar.tag;
 
     if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
 
@@ -294,23 +387,23 @@ yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *first_event)
         if (!tag) goto error;
     }
 
-    SCALAR_NODE_INIT(node, tag, first_event->data.scalar.value,
-            first_event->data.scalar.length, first_event->data.scalar.style,
-            first_event->start_mark, first_event->end_mark);
+    SCALAR_NODE_INIT(node, tag, event->data.scalar.value,
+            event->data.scalar.length, event->data.scalar.style,
+            event->start_mark, event->end_mark);
 
     if (!PUSH(parser, parser->document->nodes, node)) goto error;
 
     index = (int)(parser->document->nodes.top - parser->document->nodes.start);
 
     if (!yaml_parser_register_anchor(parser, index,
-                first_event->data.scalar.anchor)) return 0;
+                event->data.scalar.anchor)) return 0;
 
-    return index;
+    return yaml_parser_load_node_add(parser, ctx, index);
 
 error:
     yaml_free(tag);
-    yaml_free(first_event->data.scalar.anchor);
-    yaml_free(first_event->data.scalar.value);
+    yaml_free(event->data.scalar.anchor);
+    yaml_free(event->data.scalar.value);
     return 0;
 }
 
@@ -319,17 +412,17 @@ error:
  */
 
 static int
-yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event)
+yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx)
 {
-    yaml_event_t event;
     yaml_node_t node;
     struct {
         yaml_node_item_t *start;
         yaml_node_item_t *end;
         yaml_node_item_t *top;
     } items = { NULL, NULL, NULL };
-    int index, item_index;
-    yaml_char_t *tag = first_event->data.sequence_start.tag;
+    int index;
+    yaml_char_t *tag = event->data.sequence_start.tag;
 
     if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
 
@@ -342,38 +435,44 @@ yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event)
     if (!STACK_INIT(parser, items, yaml_node_item_t*)) goto error;
 
     SEQUENCE_NODE_INIT(node, tag, items.start, items.end,
-            first_event->data.sequence_start.style,
-            first_event->start_mark, first_event->end_mark);
+            event->data.sequence_start.style,
+            event->start_mark, event->end_mark);
 
     if (!PUSH(parser, parser->document->nodes, node)) goto error;
 
     index = (int)(parser->document->nodes.top - parser->document->nodes.start);
 
     if (!yaml_parser_register_anchor(parser, index,
-                first_event->data.sequence_start.anchor)) return 0;
+                event->data.sequence_start.anchor)) return 0;
 
-    if (!yaml_parser_parse(parser, &event)) return 0;
+    if (!yaml_parser_load_node_add(parser, ctx, index)) return 0;
 
-    while (event.type != YAML_SEQUENCE_END_EVENT) {
-        if (!STACK_LIMIT(parser,
-                    parser->document->nodes.start[index-1].data.sequence.items,
-                    INT_MAX-1)) return 0;
-        item_index = yaml_parser_load_node(parser, &event);
-        if (!item_index) return 0;
-        if (!PUSH(parser,
-                    parser->document->nodes.start[index-1].data.sequence.items,
-                    item_index)) return 0;
-        if (!yaml_parser_parse(parser, &event)) return 0;
-    }
+    if (!STACK_LIMIT(parser, *ctx, INT_MAX-1)) return 0;
+    if (!PUSH(parser, *ctx, index)) return 0;
 
-    parser->document->nodes.start[index-1].end_mark = event.end_mark;
-
-    return index;
+    return 1;
 
 error:
     yaml_free(tag);
-    yaml_free(first_event->data.sequence_start.anchor);
+    yaml_free(event->data.sequence_start.anchor);
     return 0;
+}
+
+static int
+yaml_parser_load_sequence_end(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx)
+{
+    int index;
+
+    assert(((*ctx).top - (*ctx).start) > 0);
+
+    index = *((*ctx).top - 1);
+    assert(parser->document->nodes.start[index-1].type == YAML_SEQUENCE_NODE);
+    parser->document->nodes.start[index-1].end_mark = event->end_mark;
+
+    (void)POP(parser, *ctx);
+
+    return 1;
 }
 
 /*
@@ -381,9 +480,9 @@ error:
  */
 
 static int
-yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
+yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx)
 {
-    yaml_event_t event;
     yaml_node_t node;
     struct {
         yaml_node_pair_t *start;
@@ -391,8 +490,7 @@ yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
         yaml_node_pair_t *top;
     } pairs = { NULL, NULL, NULL };
     int index;
-    yaml_node_pair_t pair;
-    yaml_char_t *tag = first_event->data.mapping_start.tag;
+    yaml_char_t *tag = event->data.mapping_start.tag;
 
     if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
 
@@ -405,40 +503,42 @@ yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
     if (!STACK_INIT(parser, pairs, yaml_node_pair_t*)) goto error;
 
     MAPPING_NODE_INIT(node, tag, pairs.start, pairs.end,
-            first_event->data.mapping_start.style,
-            first_event->start_mark, first_event->end_mark);
+            event->data.mapping_start.style,
+            event->start_mark, event->end_mark);
 
     if (!PUSH(parser, parser->document->nodes, node)) goto error;
 
     index = (int)(parser->document->nodes.top - parser->document->nodes.start);
 
     if (!yaml_parser_register_anchor(parser, index,
-                first_event->data.mapping_start.anchor)) return 0;
+                event->data.mapping_start.anchor)) return 0;
 
-    if (!yaml_parser_parse(parser, &event)) return 0;
+    if (!yaml_parser_load_node_add(parser, ctx, index)) return 0;
 
-    while (event.type != YAML_MAPPING_END_EVENT) {
-        if (!STACK_LIMIT(parser,
-                    parser->document->nodes.start[index-1].data.mapping.pairs,
-                    INT_MAX-1)) return 0;
-        pair.key = yaml_parser_load_node(parser, &event);
-        if (!pair.key) return 0;
-        if (!yaml_parser_parse(parser, &event)) return 0;
-        pair.value = yaml_parser_load_node(parser, &event);
-        if (!pair.value) return 0;
-        if (!PUSH(parser,
-                    parser->document->nodes.start[index-1].data.mapping.pairs,
-                    pair)) return 0;
-        if (!yaml_parser_parse(parser, &event)) return 0;
-    }
+    if (!STACK_LIMIT(parser, *ctx, INT_MAX-1)) return 0;
+    if (!PUSH(parser, *ctx, index)) return 0;
 
-    parser->document->nodes.start[index-1].end_mark = event.end_mark;
-
-    return index;
+    return 1;
 
 error:
     yaml_free(tag);
-    yaml_free(first_event->data.mapping_start.anchor);
+    yaml_free(event->data.mapping_start.anchor);
     return 0;
 }
 
+static int
+yaml_parser_load_mapping_end(yaml_parser_t *parser, yaml_event_t *event,
+        struct loader_ctx *ctx)
+{
+    int index;
+
+    assert(((*ctx).top - (*ctx).start) > 0);
+
+    index = *((*ctx).top - 1);
+    assert(parser->document->nodes.start[index-1].type == YAML_MAPPING_NODE);
+    parser->document->nodes.start[index-1].end_mark = event->end_mark;
+
+    (void)POP(parser, *ctx);
+
+    return 1;
+}

--- a/ext/psych/yaml/parser.c
+++ b/ext/psych/yaml/parser.c
@@ -1261,7 +1261,10 @@ yaml_parser_process_directives(yaml_parser_t *parser,
                 goto error;
             }
             if (token->data.version_directive.major != 1
-                    || token->data.version_directive.minor != 1) {
+                    || (
+                        token->data.version_directive.minor != 1
+                        && token->data.version_directive.minor != 2
+                    )) {
                 yaml_parser_set_parser_error(parser,
                         "found incompatible YAML document", token->start_mark);
                 goto error;
@@ -1316,6 +1319,8 @@ yaml_parser_process_directives(yaml_parser_t *parser,
         STACK_DEL(parser, tag_directives);
     }
 
+    if (!version_directive_ref)
+        yaml_free(version_directive);
     return 1;
 
 error:

--- a/ext/psych/yaml/scanner.c
+++ b/ext/psych/yaml/scanner.c
@@ -38,8 +38,8 @@
  *      BLOCK-END                       # Indentation decrease.
  *      FLOW-SEQUENCE-START             # '['
  *      FLOW-SEQUENCE-END               # ']'
- *      BLOCK-SEQUENCE-START            # '{'
- *      BLOCK-SEQUENCE-END              # '}'
+ *      FLOW-MAPPING-START              # '{'
+ *      FLOW-MAPPING-END                # '}'
  *      BLOCK-ENTRY                     # '-'
  *      FLOW-ENTRY                      # ','
  *      KEY                             # '?' or nothing (simple keys).
@@ -348,6 +348,7 @@
  *          SCALAR("another value",plain)
  *          KEY
  *          SCALAR("a mapping",plain)
+ *          VALUE
  *          BLOCK-MAPPING-START
  *          KEY
  *          SCALAR("key 1",plain)
@@ -711,7 +712,7 @@ yaml_parser_scan_tag_handle(yaml_parser_t *parser, int directive,
         yaml_mark_t start_mark, yaml_char_t **handle);
 
 static int
-yaml_parser_scan_tag_uri(yaml_parser_t *parser, int directive,
+yaml_parser_scan_tag_uri(yaml_parser_t *parser, int uri_char, int directive,
         yaml_char_t *head, yaml_mark_t start_mark, yaml_char_t **uri);
 
 static int
@@ -2292,7 +2293,7 @@ yaml_parser_scan_tag_directive_value(yaml_parser_t *parser,
 
     /* Scan a prefix. */
 
-    if (!yaml_parser_scan_tag_uri(parser, 1, NULL, start_mark, &prefix_value))
+    if (!yaml_parser_scan_tag_uri(parser, 1, 1, NULL, start_mark, &prefix_value))
         goto error;
 
     /* Expect a whitespace or line break. */
@@ -2410,7 +2411,7 @@ yaml_parser_scan_tag(yaml_parser_t *parser, yaml_token_t *token)
 
         /* Consume the tag value. */
 
-        if (!yaml_parser_scan_tag_uri(parser, 0, NULL, start_mark, &suffix))
+        if (!yaml_parser_scan_tag_uri(parser, 1, 0, NULL, start_mark, &suffix))
             goto error;
 
         /* Check for '>' and eat it. */
@@ -2438,14 +2439,14 @@ yaml_parser_scan_tag(yaml_parser_t *parser, yaml_token_t *token)
         {
             /* Scan the suffix now. */
 
-            if (!yaml_parser_scan_tag_uri(parser, 0, NULL, start_mark, &suffix))
+            if (!yaml_parser_scan_tag_uri(parser, 0, 0, NULL, start_mark, &suffix))
                 goto error;
         }
         else
         {
             /* It wasn't a handle after all.  Scan the rest of the tag. */
 
-            if (!yaml_parser_scan_tag_uri(parser, 0, handle, start_mark, &suffix))
+            if (!yaml_parser_scan_tag_uri(parser, 0, 0, handle, start_mark, &suffix))
                 goto error;
 
             /* Set the handle to '!'. */
@@ -2474,9 +2475,11 @@ yaml_parser_scan_tag(yaml_parser_t *parser, yaml_token_t *token)
     if (!CACHE(parser, 1)) goto error;
 
     if (!IS_BLANKZ(parser->buffer)) {
-        yaml_parser_set_scanner_error(parser, "while scanning a tag",
-                start_mark, "did not find expected whitespace or line break");
-        goto error;
+        if (!parser->flow_level || !CHECK(parser->buffer, ',') ) {
+            yaml_parser_set_scanner_error(parser, "while scanning a tag",
+                    start_mark, "did not find expected whitespace or line break");
+            goto error;
+        }
     }
 
     end_mark = parser->mark;
@@ -2565,7 +2568,7 @@ error:
  */
 
 static int
-yaml_parser_scan_tag_uri(yaml_parser_t *parser, int directive,
+yaml_parser_scan_tag_uri(yaml_parser_t *parser, int uri_char, int directive,
         yaml_char_t *head, yaml_mark_t start_mark, yaml_char_t **uri)
 {
     size_t length = head ? strlen((char *)head) : 0;
@@ -2601,8 +2604,11 @@ yaml_parser_scan_tag_uri(yaml_parser_t *parser, int directive,
      * The set of characters that may appear in URI is as follows:
      *
      *      '0'-'9', 'A'-'Z', 'a'-'z', '_', '-', ';', '/', '?', ':', '@', '&',
-     *      '=', '+', '$', ',', '.', '!', '~', '*', '\'', '(', ')', '[', ']',
-     *      '%'.
+     *      '=', '+', '$', '.', '!', '~', '*', '\'', '(', ')', '%'.
+     *
+     * If we are inside a verbatim tag <...> (parameter uri_char is true)
+     * then also the following flow indicators are allowed:
+     *      ',', '[', ']'
      */
 
     while (IS_ALPHA(parser->buffer) || CHECK(parser->buffer, ';')
@@ -2610,12 +2616,15 @@ yaml_parser_scan_tag_uri(yaml_parser_t *parser, int directive,
             || CHECK(parser->buffer, ':') || CHECK(parser->buffer, '@')
             || CHECK(parser->buffer, '&') || CHECK(parser->buffer, '=')
             || CHECK(parser->buffer, '+') || CHECK(parser->buffer, '$')
-            || CHECK(parser->buffer, ',') || CHECK(parser->buffer, '.')
+            || CHECK(parser->buffer, '.') || CHECK(parser->buffer, '%')
             || CHECK(parser->buffer, '!') || CHECK(parser->buffer, '~')
             || CHECK(parser->buffer, '*') || CHECK(parser->buffer, '\'')
             || CHECK(parser->buffer, '(') || CHECK(parser->buffer, ')')
-            || CHECK(parser->buffer, '[') || CHECK(parser->buffer, ']')
-            || CHECK(parser->buffer, '%'))
+            || (uri_char && (
+                CHECK(parser->buffer, ',')
+                || CHECK(parser->buffer, '[') || CHECK(parser->buffer, ']')
+                )
+            ))
     {
         /* Check if it is a URI-escape sequence. */
 
@@ -2860,7 +2869,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
     if (!CACHE(parser, 1)) goto error;
 
-    while ((int)parser->mark.column == indent && !IS_Z(parser->buffer))
+    while ((int)parser->mark.column == indent && !(IS_Z(parser->buffer)))
     {
         /*
          * We are at the beginning of a non-empty line.
@@ -3430,11 +3439,22 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
 
         while (!IS_BLANKZ(parser->buffer))
         {
-            /* Check for 'x:x' in the flow context. TODO: Fix the test "spec-08-13". */
+            /* Check for "x:" + one of ',?[]{}' in the flow context. TODO: Fix the test "spec-08-13".
+             * This is not completely according to the spec
+             * See http://yaml.org/spec/1.1/#id907281 9.1.3. Plain
+             */
 
             if (parser->flow_level
                     && CHECK(parser->buffer, ':')
-                    && !IS_BLANKZ_AT(parser->buffer, 1)) {
+                    && (
+                        CHECK_AT(parser->buffer, ',', 1)
+                        || CHECK_AT(parser->buffer, '?', 1)
+                        || CHECK_AT(parser->buffer, '[', 1)
+                        || CHECK_AT(parser->buffer, ']', 1)
+                        || CHECK_AT(parser->buffer, '{', 1)
+                        || CHECK_AT(parser->buffer, '}', 1)
+                    )
+                    ) {
                 yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
                         start_mark, "found unexpected ':'");
                 goto error;
@@ -3444,8 +3464,8 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
 
             if ((CHECK(parser->buffer, ':') && IS_BLANKZ_AT(parser->buffer, 1))
                     || (parser->flow_level &&
-                        (CHECK(parser->buffer, ',') || CHECK(parser->buffer, ':')
-                         || CHECK(parser->buffer, '?') || CHECK(parser->buffer, '[')
+                        (CHECK(parser->buffer, ',')
+                         || CHECK(parser->buffer, '[')
                          || CHECK(parser->buffer, ']') || CHECK(parser->buffer, '{')
                          || CHECK(parser->buffer, '}'))))
                 break;
@@ -3512,7 +3532,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
                 if (leading_blanks && (int)parser->mark.column < indent
                         && IS_TAB(parser->buffer)) {
                     yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
-                            start_mark, "found a tab character that violate indentation");
+                            start_mark, "found a tab character that violates indentation");
                     goto error;
                 }
 

--- a/ext/psych/yaml/yaml.h
+++ b/ext/psych/yaml/yaml.h
@@ -1,7 +1,7 @@
 /**
  * @file yaml.h
  * @brief Public interface for libyaml.
- *
+ * 
  * Include the header file with the code:
  * @code
  * #include <yaml.h>
@@ -26,7 +26,9 @@ extern "C" {
 
 /** The public API declaration. */
 
-#ifdef _WIN32
+#if defined(__MINGW32__)
+#   define  YAML_DECLARE(type)  type
+#elif defined(_WIN32)
 #   if defined(YAML_DECLARE_STATIC)
 #       define  YAML_DECLARE(type)  type
 #   elif defined(YAML_DECLARE_EXPORT)
@@ -230,7 +232,7 @@ typedef enum yaml_token_type_e {
 
     /** A BLOCK-SEQUENCE-START token. */
     YAML_BLOCK_SEQUENCE_START_TOKEN,
-    /** A BLOCK-SEQUENCE-END token. */
+    /** A BLOCK-MAPPING-START token. */
     YAML_BLOCK_MAPPING_START_TOKEN,
     /** A BLOCK-END token. */
     YAML_BLOCK_END_TOKEN,
@@ -388,7 +390,7 @@ typedef struct yaml_event_s {
 
     /** The event data. */
     union {
-
+        
         /** The stream parameters (for @c YAML_STREAM_START_EVENT). */
         struct {
             /** The document encoding. */
@@ -550,7 +552,7 @@ yaml_document_end_event_initialize(yaml_event_t *event, int implicit);
  */
 
 YAML_DECLARE(int)
-yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor);
+yaml_alias_event_initialize(yaml_event_t *event, const yaml_char_t *anchor);
 
 /**
  * Create a SCALAR event.
@@ -576,8 +578,8 @@ yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor);
 
 YAML_DECLARE(int)
 yaml_scalar_event_initialize(yaml_event_t *event,
-        yaml_char_t *anchor, yaml_char_t *tag,
-        yaml_char_t *value, int length,
+        const yaml_char_t *anchor, const yaml_char_t *tag,
+        const yaml_char_t *value, int length,
         int plain_implicit, int quoted_implicit,
         yaml_scalar_style_t style);
 
@@ -599,7 +601,7 @@ yaml_scalar_event_initialize(yaml_event_t *event,
 
 YAML_DECLARE(int)
 yaml_sequence_start_event_initialize(yaml_event_t *event,
-        yaml_char_t *anchor, yaml_char_t *tag, int implicit,
+        const yaml_char_t *anchor, const yaml_char_t *tag, int implicit,
         yaml_sequence_style_t style);
 
 /**
@@ -631,7 +633,7 @@ yaml_sequence_end_event_initialize(yaml_event_t *event);
 
 YAML_DECLARE(int)
 yaml_mapping_start_event_initialize(yaml_event_t *event,
-        yaml_char_t *anchor, yaml_char_t *tag, int implicit,
+        const yaml_char_t *anchor, const yaml_char_t *tag, int implicit,
         yaml_mapping_style_t style);
 
 /**
@@ -663,7 +665,7 @@ yaml_event_delete(yaml_event_t *event);
 
 /** The tag @c !!null with the only possible value: @c null. */
 #define YAML_NULL_TAG       "tag:yaml.org,2002:null"
-/** The tag @c !!bool with the values: @c true and @c falce. */
+/** The tag @c !!bool with the values: @c true and @c false. */
 #define YAML_BOOL_TAG       "tag:yaml.org,2002:bool"
 /** The tag @c !!str for string values. */
 #define YAML_STR_TAG        "tag:yaml.org,2002:str"
@@ -724,7 +726,7 @@ struct yaml_node_s {
 
     /** The node data. */
     union {
-
+        
         /** The scalar parameters (for @c YAML_SCALAR_NODE). */
         struct {
             /** The scalar value. */
@@ -894,7 +896,7 @@ yaml_document_get_root_node(yaml_document_t *document);
 
 YAML_DECLARE(int)
 yaml_document_add_scalar(yaml_document_t *document,
-        yaml_char_t *tag, yaml_char_t *value, int length,
+        const yaml_char_t *tag, const yaml_char_t *value, int length,
         yaml_scalar_style_t style);
 
 /**
@@ -911,7 +913,7 @@ yaml_document_add_scalar(yaml_document_t *document,
 
 YAML_DECLARE(int)
 yaml_document_add_sequence(yaml_document_t *document,
-        yaml_char_t *tag, yaml_sequence_style_t style);
+        const yaml_char_t *tag, yaml_sequence_style_t style);
 
 /**
  * Create a MAPPING node and attach it to the document.
@@ -927,7 +929,7 @@ yaml_document_add_sequence(yaml_document_t *document,
 
 YAML_DECLARE(int)
 yaml_document_add_mapping(yaml_document_t *document,
-        yaml_char_t *tag, yaml_mapping_style_t style);
+        const yaml_char_t *tag, yaml_mapping_style_t style);
 
 /**
  * Add an item to a SEQUENCE node.
@@ -935,7 +937,7 @@ yaml_document_add_mapping(yaml_document_t *document,
  * @param[in,out]   document    A document object.
  * @param[in]       sequence    The sequence node id.
  * @param[in]       item        The item node id.
-*
+ *
  * @returns @c 1 if the function succeeded, @c 0 on error.
  */
 
@@ -950,7 +952,7 @@ yaml_document_append_sequence_item(yaml_document_t *document,
  * @param[in]       mapping     The mapping node id.
  * @param[in]       key         The key node id.
  * @param[in]       value       The value node id.
-*
+ *
  * @returns @c 1 if the function succeeded, @c 0 on error.
  */
 
@@ -1018,6 +1020,7 @@ typedef enum yaml_parser_state_e {
     YAML_PARSE_DOCUMENT_CONTENT_STATE,
     /** Expect DOCUMENT-END. */
     YAML_PARSE_DOCUMENT_END_STATE,
+
     /** Expect a block node. */
     YAML_PARSE_BLOCK_NODE_STATE,
     /** Expect a block node or indentless sequence. */
@@ -1028,6 +1031,7 @@ typedef enum yaml_parser_state_e {
     YAML_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE,
     /** Expect an entry of a block sequence. */
     YAML_PARSE_BLOCK_SEQUENCE_ENTRY_STATE,
+
     /** Expect an entry of an indentless sequence. */
     YAML_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE,
     /** Expect the first key of a block mapping. */
@@ -1038,6 +1042,7 @@ typedef enum yaml_parser_state_e {
     YAML_PARSE_BLOCK_MAPPING_VALUE_STATE,
     /** Expect the first entry of a flow sequence. */
     YAML_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE,
+
     /** Expect an entry of a flow sequence. */
     YAML_PARSE_FLOW_SEQUENCE_ENTRY_STATE,
     /** Expect a key of an ordered mapping. */
@@ -1049,6 +1054,7 @@ typedef enum yaml_parser_state_e {
     /** Expect the first key of a flow mapping. */
     YAML_PARSE_FLOW_MAPPING_FIRST_KEY_STATE,
     /** Expect a key of a flow mapping. */
+
     YAML_PARSE_FLOW_MAPPING_KEY_STATE,
     /** Expect a value of a flow mapping. */
     YAML_PARSE_FLOW_MAPPING_VALUE_STATE,
@@ -1089,7 +1095,7 @@ typedef struct yaml_parser_s {
     yaml_error_type_t error;
     /** Error description. */
     const char *problem;
-    /** The byte about which the problem occurred. */
+    /** The byte about which the problem occured. */
     size_t problem_offset;
     /** The problematic value (@c -1 is none). */
     int problem_value;
@@ -1203,7 +1209,7 @@ typedef struct yaml_parser_s {
     /** The number of tokens fetched from the queue. */
     size_t tokens_parsed;
 
-    /* Does the tokens queue contain a token ready for dequeueing. */
+    /** Does the tokens queue contain a token ready for dequeueing. */
     int token_available;
 
     /** The indentation levels stack. */
@@ -1444,7 +1450,7 @@ yaml_parser_parse(yaml_parser_t *parser, yaml_event_t *event);
  * @param[in,out]   parser      A parser object.
  * @param[out]      document    An empty document object.
  *
- * @return @c 1 if the function succeeded, @c 0 on error.
+ * @returns @c 1 if the function succeeded, @c 0 on error.
  */
 
 YAML_DECLARE(int)
@@ -1487,6 +1493,7 @@ typedef enum yaml_emitter_state_e {
     YAML_EMIT_DOCUMENT_CONTENT_STATE,
     /** Expect DOCUMENT-END. */
     YAML_EMIT_DOCUMENT_END_STATE,
+
     /** Expect the first item of a flow sequence. */
     YAML_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE,
     /** Expect an item of a flow sequence. */
@@ -1497,6 +1504,7 @@ typedef enum yaml_emitter_state_e {
     YAML_EMIT_FLOW_MAPPING_KEY_STATE,
     /** Expect a value for a simple key of a flow mapping. */
     YAML_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE,
+
     /** Expect a value of a flow mapping. */
     YAML_EMIT_FLOW_MAPPING_VALUE_STATE,
     /** Expect the first item of a block sequence. */
@@ -1507,6 +1515,7 @@ typedef enum yaml_emitter_state_e {
     YAML_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE,
     /** Expect the key of a block mapping. */
     YAML_EMIT_BLOCK_MAPPING_KEY_STATE,
+
     /** Expect a value for a simple key of a block mapping. */
     YAML_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE,
     /** Expect a value of a block mapping. */
@@ -1514,6 +1523,18 @@ typedef enum yaml_emitter_state_e {
     /** Expect nothing. */
     YAML_EMIT_END_STATE
 } yaml_emitter_state_t;
+
+
+/* This is needed for C++ */
+
+typedef struct yaml_anchors_s {
+    /** The number of references. */
+    int references;
+    /** The anchor id. */
+    int anchor;
+    /** If the node has been emitted? */
+    int serialized;
+} yaml_anchors_t;
 
 /**
  * The emitter structure.
@@ -1546,7 +1567,7 @@ typedef struct yaml_emitter_s {
     /** Write handler. */
     yaml_write_handler_t *write_handler;
 
-    /** A pointer for passing to the white handler. */
+    /** A pointer for passing to the write handler. */
     void *write_handler_data;
 
     /** Standard (string or file) output data. */
@@ -1740,14 +1761,7 @@ typedef struct yaml_emitter_s {
     int closed;
 
     /** The information associated with the document nodes. */
-    struct {
-        /** The number of references. */
-        int references;
-        /** The anchor id. */
-        int anchor;
-        /** If the node has been emitted? */
-        int serialized;
-    } *anchors;
+    yaml_anchors_t *anchors;
 
     /** The last assigned anchor id. */
     int last_anchor_id;
@@ -1938,8 +1952,8 @@ yaml_emitter_close(yaml_emitter_t *emitter);
  *
  * The documen object may be generated using the yaml_parser_load() function
  * or the yaml_document_initialize() function.  The emitter takes the
- * responsibility for the document object and destoys its content after
- * it is emitted. The document object is destroyedeven if the function fails.
+ * responsibility for the document object and destroys its content after
+ * it is emitted. The document object is destroyed even if the function fails.
  *
  * @param[in,out]   emitter     An emitter object.
  * @param[in,out]   document    A document object.

--- a/ext/psych/yaml/yaml_private.h
+++ b/ext/psych/yaml/yaml_private.h
@@ -3,7 +3,7 @@
 #endif
 
 #if HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <yaml.h>
@@ -175,14 +175,14 @@ yaml_string_join(
  * Check the octet at the specified position.
  */
 
-#define CHECK_AT(string,octet,offset)                                           \
+#define CHECK_AT(string,octet,offset)                   \
     ((string).pointer[offset] == (yaml_char_t)(octet))
 
 /*
  * Check the current octet in the buffer.
  */
 
-#define CHECK(string,octet) CHECK_AT((string),(octet),0)
+#define CHECK(string,octet) (CHECK_AT((string),(octet),0))
 
 /*
  * Check if the character at the specified position is an alphabetical

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -60,7 +60,7 @@ DESCRIPTION
       "lib/psych_jars.rb",
       "lib/psych.jar"
     ]
-    s.requirements = "jar org.yaml:snakeyaml, #{Psych::DEFAULT_SNAKEYAML_VERSION}"
+    s.requirements = "jar org.yaml:snakeyaml, #{version_module::Psych::DEFAULT_SNAKEYAML_VERSION}"
     s.add_dependency 'jar-dependencies', '>= 0.1.7'
   else
     s.extensions = ["ext/psych/extconf.rb"]


### PR DESCRIPTION
I merged [libyaml-0.2.5](https://github.com/yaml/libyaml/releases/tag/0.2.5) and re-apply our local patches like

* https://gist.github.com/hsbt/0092f2674704c498285522167fb2ef15
* https://github.com/ruby/ruby/commit/2d189a6721c5e88973a53e385c0fb9eeb55fece9#diff-c1b26d426eec2eee52a57512a8bbf5ab
* https://github.com/ruby/ruby/commit/39622232c7542d062f79277a11f6b8b6b6cfd994#diff-c1b26d426eec2eee52a57512a8bbf5ab
* https://github.com/ruby/ruby/commit/58a478bce4a81e619dcef4436f437453d1a3cd89#diff-c1b26d426eec2eee52a57512a8bbf5ab
* https://github.com/ruby/ruby/commit/571ffcd6094ccf1c68d4bfc36e425e0ee524e8b4#diff-c1b26d426eec2eee52a57512a8bbf5ab