### PR TITLE
Remove private_iv_get

### DIFF
--- a/ext/java/org/jruby/ext/psych/PsychYamlTree.java
+++ b/ext/java/org/jruby/ext/psych/PsychYamlTree.java
@@ -44,12 +44,4 @@ public class PsychYamlTree {
 
         psychYamlTree.defineAnnotatedMethods(PsychYamlTree.class);
     }
-
-    @JRubyMethod(visibility = PRIVATE)
-    public static IRubyObject private_iv_get(ThreadContext context, IRubyObject self, IRubyObject target, IRubyObject prop) {
-        IRubyObject obj = (IRubyObject)target.getInternalVariables().getInternalVariable(prop.asJavaString());
-        if (obj == null) obj = context.nil;
-
-        return obj;
-    }
 }

--- a/ext/psych/psych_yaml_tree.c
+++ b/ext/psych/psych_yaml_tree.c
@@ -2,23 +2,11 @@
 
 VALUE cPsychVisitorsYamlTree;
 
-/*
- * call-seq: private_iv_get(target, prop)
- *
- * Get the private instance variable +prop+ from +target+
- */
-static VALUE private_iv_get(VALUE self, VALUE target, VALUE prop)
-{
-    return rb_attr_get(target, rb_intern(StringValueCStr(prop)));
-}
-
 void Init_psych_yaml_tree(void)
 {
     VALUE psych     = rb_define_module("Psych");
     VALUE visitors  = rb_define_module_under(psych, "Visitors");
     VALUE visitor   = rb_define_class_under(visitors, "Visitor", rb_cObject);
     cPsychVisitorsYamlTree = rb_define_class_under(visitors, "YAMLTree", visitor);
-
-    rb_define_private_method(cPsychVisitorsYamlTree, "private_iv_get", private_iv_get, 2);
 }
 /* vim: set noet sws=4 sw=4: */

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -181,7 +181,7 @@ module Psych
       end
 
       def visit_Exception o
-        dump_exception o, private_iv_get(o, 'mesg')
+        dump_exception o, o.message.to_s
       end
 
       def visit_NameError o

--- a/test/psych/test_exception.rb
+++ b/test/psych/test_exception.rb
@@ -154,7 +154,8 @@ module Psych
 
     def test_convert
       w = Psych.load(Psych.dump(@wups))
-      assert_equal @wups, w
+      assert_equal @wups.message, w.message
+      assert_equal @wups.backtrace, w.backtrace
       assert_equal 1, w.foo
       assert_equal 2, w.bar
     end


### PR DESCRIPTION
The only remaining use of this function was to get the internal message object from an exception's hidden `mesg` instance variable to allow it to be dumped wiithout converting to a string.

As discussed in #103, this exposes internal implementation details of CRuby, and ultimately does not provide any real utility to the user since they can't directly inspect this hidden variable. The test change here is to reflect CRuby behavior that denies equality if the internal message objects do not match, as is the case after the exception has been loaded and now has a simple String value.

The impact to users is that exceptions with special hidden message objects will convert those objects to String during marshaling through YAML. I believe this only affects NameError and its descendants, since users can't set this field directly on their own exception types.

Fixes #103.