### PR TITLE
Remove unneeded assignment and condition

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -276,8 +276,7 @@ module Psych
 
     result = parse(yaml, filename: filename)
     return fallback unless result
-    result = result.to_ruby(symbolize_names: symbolize_names, freeze: freeze) if result
-    result
+    result.to_ruby(symbolize_names: symbolize_names, freeze: freeze)
   end
 
   ###


### PR DESCRIPTION
Since we already `return fallback` if `result` is falsy, we don't need to check again if it's truthy and reassign the `to_ruby` result.