### PR TITLE
Improve float scalar scanner

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -9,9 +9,8 @@ module Psych
     TIME = /^-?\d{4}-\d{1,2}-\d{1,2}(?:[Tt]|\s+)\d{1,2}:\d\d:\d\d(?:\.\d*)?(?:\s*(?:Z|[-+]\d{1,2}:?(?:\d\d)?))?$/
 
     # Taken from http://yaml.org/type/float.html
-    FLOAT = /^(?:[-+]?([0-9][0-9_,]*)?\.[0-9]*([eE][-+][0-9]+)?(?# base 10)
-              |[-+]?\.(inf|Inf|INF)(?# infinity)
-              |\.(nan|NaN|NAN)(?# not a number))$/x
+    # Base 60, [-+]inf and NaN are handled separately
+    FLOAT = /^(?:[-+]?([0-9][0-9_,]*)?\.[0-9]*([eE][-+][0-9]+)?(?# base 10))$/x
 
     # Taken from http://yaml.org/type/int.html
     INTEGER = /^(?:[-+]?0b[0-1_,]+          (?# base 2)
@@ -61,7 +60,7 @@ module Psych
         rescue ArgumentError
           string
         end
-      elsif string.match?(/^\.inf$/i)
+      elsif string.match?(/^\+?\.inf$/i)
         Float::INFINITY
       elsif string.match?(/^-\.inf$/i)
         -Float::INFINITY

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -66,6 +66,10 @@ module Psych
       assert_equal(1 / 0.0, ss.tokenize('.inf'))
     end
 
+    def test_scan_plus_inf
+      assert_equal(1 / 0.0, ss.tokenize('+.inf'))
+    end
+
     def test_scan_minus_inf
       assert_equal(-1 / 0.0, ss.tokenize('-.inf'))
     end
@@ -132,6 +136,14 @@ module Psych
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef')
       assert_equal 0x123456789abcdef, ss.tokenize('0x_12_,34,_56,_789abcdef')
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef__')
+    end
+
+    def test_scan_dot
+      assert_equal '.', ss.tokenize('.')
+    end
+
+    def test_scan_plus_dot
+      assert_equal '+.', ss.tokenize('+.')
     end
   end
 end


### PR DESCRIPTION
Previously, `+.inf` was not handled correctly. Additionally, the regexp
was checking for inf and NaN, even though these cases are handled earlier
in the condition. Added a few tests to ensure handling some missing
cases.