### PR TITLE
Forward keyword arguments in load_file and load_stream

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -549,7 +549,7 @@ module Psych
   #   end
   #   list # => ['foo', 'bar']
   #
-  def self.load_stream yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: []
+  def self.load_stream yaml, legacy_filename = NOT_GIVEN, filename: nil, fallback: [], **kwargs
     if legacy_filename != NOT_GIVEN
       warn_with_uplevel 'Passing filename with the 2nd argument of Psych.load_stream is deprecated. Use keyword argument like Psych.load_stream(yaml, filename: ...) instead.', uplevel: 1 if $VERBOSE
       filename = legacy_filename
@@ -557,10 +557,10 @@ module Psych
 
     result = if block_given?
                parse_stream(yaml, filename: filename) do |node|
-                 yield node.to_ruby
+                 yield node.to_ruby(**kwargs)
                end
              else
-               parse_stream(yaml, filename: filename).children.map(&:to_ruby)
+               parse_stream(yaml, filename: filename).children.map { |node| node.to_ruby(**kwargs) }
              end
 
     return fallback if result.is_a?(Array) && result.empty?
@@ -571,9 +571,9 @@ module Psych
   # Load the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
   # the specified +fallback+ return value, which defaults to +false+.
-  def self.load_file filename, fallback: false
+  def self.load_file filename, **kwargs
     File.open(filename, 'r:bom|utf-8') { |f|
-      self.load f, filename: filename, fallback: fallback
+      self.load f, filename: filename, **kwargs
     }
   end
 

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -125,6 +125,19 @@ class TestPsych < Psych::TestCase
     assert_equal %w{ foo bar }, docs
   end
 
+  def test_load_stream_freeze
+    docs = Psych.load_stream("--- foo\n...\n--- bar\n...", freeze: true)
+    assert_equal %w{ foo bar }, docs
+    docs.each do |string|
+      assert_predicate string, :frozen?
+    end
+  end
+
+  def test_load_stream_symbolize_names
+    docs = Psych.load_stream("---\nfoo: bar", symbolize_names: true)
+    assert_equal [{foo: 'bar'}], docs
+  end
+
   def test_load_stream_default_fallback
     assert_equal [], Psych.load_stream("")
   end
@@ -239,6 +252,27 @@ class TestPsych < Psych::TestCase
       t.write('--- hello world')
       t.close
       assert_equal 'hello world', Psych.load_file(t.path)
+    }
+  end
+
+  def test_load_file_freeze
+    Tempfile.create(['yikes', 'yml']) {|t|
+      t.binmode
+      t.write('--- hello world')
+      t.close
+
+      object = Psych.load_file(t.path, freeze: true)
+      assert_predicate object, :frozen?
+    }
+  end
+
+  def test_load_file_symbolize_names
+    Tempfile.create(['yikes', 'yml']) {|t|
+      t.binmode
+      t.write("---\nfoo: bar")
+      t.close
+
+      assert_equal({foo: 'bar'}, Psych.load_file(t.path, symbolize_names: true))
     }
   end
 


### PR DESCRIPTION
`Psych.load_file` and `Pysch.load_stream` don't accept various `Psych.load` options such as `symbolize_name:` and `freeze:`.

Of course you can use `Pysch.load(File.read(path), **options)`, but [using `load_file` allows to leverage `bootsnap`'s YAML caching](https://github.com/Shopify/bootsnap/blob/e8aad0ce200e05c935e0952aadc2e8a5e95e13f4/lib/bootsnap/compile_cache/yaml.rb#L49).

cc @tenderlove 