### PR TITLE
fix parsing integer values with '_' at the end

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -14,10 +14,10 @@ module Psych
               |\.(nan|NaN|NAN)(?# not a number))$/x
 
     # Taken from http://yaml.org/type/int.html
-    INTEGER = /^(?:[-+]?0b[0-1_,]+          (?# base 2)
-                  |[-+]?0[0-7_,]+           (?# base 8)
-                  |[-+]?(?:0|[1-9][0-9_,]*) (?# base 10)
-                  |[-+]?0x[0-9a-fA-F_,]+    (?# base 16))$/x
+    INTEGER = /^(?:[-+]?0b[0-1_,]+               (?# base 2)
+                  |[-+]?0[0-7_,]+                (?# base 8)
+                  |[-+]?(?:\d|[1-9][0-9_,]*[^_]) (?# base 10)
+                  |[-+]?0x[0-9a-fA-F_,]+         (?# base 16))$/x
 
     attr_reader :class_loader
 

--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -16,7 +16,7 @@ module Psych
     # Taken from http://yaml.org/type/int.html
     INTEGER = /^(?:[-+]?0b[0-1_,]+                        (?# base 2)
                   |[-+]?0[0-7_,]+                         (?# base 8)
-                  |[-+]?(?:0|[1-9]([0-9]|,[0-9]|_[0-9])*) (?# base 10)
+                  |[-+]?(?:0|[1-9](?:[0-9]|,[0-9]|_[0-9])*) (?# base 10)
                   |[-+]?0x[0-9a-fA-F_,]+                  (?# base 16))$/x
 
     attr_reader :class_loader

--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -14,10 +14,10 @@ module Psych
               |\.(nan|NaN|NAN)(?# not a number))$/x
 
     # Taken from http://yaml.org/type/int.html
-    INTEGER = /^(?:[-+]?0b[0-1_,]+               (?# base 2)
-                  |[-+]?0[0-7_,]+                (?# base 8)
-                  |[-+]?(?:\d|[1-9][0-9_,]*[^_]) (?# base 10)
-                  |[-+]?0x[0-9a-fA-F_,]+         (?# base 16))$/x
+    INTEGER = /^(?:[-+]?0b[0-1_,]+                        (?# base 2)
+                  |[-+]?0[0-7_,]+                         (?# base 8)
+                  |[-+]?(?:0|[1-9]([0-9]|,[0-9]|_[0-9])*) (?# base 10)
+                  |[-+]?0x[0-9a-fA-F_,]+                  (?# base 16))$/x
 
     attr_reader :class_loader
 

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -114,13 +114,20 @@ module Psych
       assert_equal "_100", ss.tokenize('_100')
     end
 
+    def test_scan_strings_ending_with_underscores
+      assert_equal "100_", ss.tokenize('100_')
+    end
+
     def test_scan_int_commas_and_underscores
       # NB: This test is to ensure backward compatibility with prior Psych versions,
       # not to test against any actual YAML specification.
       assert_equal 123_456_789, ss.tokenize('123_456_789')
       assert_equal 123_456_789, ss.tokenize('123,456,789')
       assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789')
-      assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789_')
+
+      assert_equal 1, ss.tokenize('1')
+      assert_equal 1 ss.tokenize('+1')
+      assert_equal -1 ss.tokenize('-1')
 
       assert_equal 0b010101010, ss.tokenize('0b010101010')
       assert_equal 0b010101010, ss.tokenize('0b0,1_0,1_,0,1_01,0')

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -111,11 +111,15 @@ module Psych
     end
 
     def test_scan_strings_starting_with_underscores
-      assert_equal "_100", ss.tokenize('_100')
+      assert_equal '_100', ss.tokenize('_100')
+    end
+
+    def test_scan_strings_starting_with_number
+      assert_equal '450D', ss.tokenize('450D')
     end
 
     def test_scan_strings_ending_with_underscores
-      assert_equal "100_", ss.tokenize('100_')
+      assert_equal '100_', ss.tokenize('100_')
     end
 
     def test_scan_int_commas_and_underscores

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -126,8 +126,8 @@ module Psych
       assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789')
 
       assert_equal 1, ss.tokenize('1')
-      assert_equal 1 ss.tokenize('+1')
-      assert_equal -1 ss.tokenize('-1')
+      assert_equal 1, ss.tokenize('+1')
+      assert_equal -1, ss.tokenize('-1')
 
       assert_equal 0b010101010, ss.tokenize('0b010101010')
       assert_equal 0b010101010, ss.tokenize('0b0,1_0,1_,0,1_01,0')


### PR DESCRIPTION
Hello, We have issue when we parse integer values with `_` at the end, parser removes `_` and then we have just integer. I am pretty sure this is right behaviour for ruby language, but when you are working with customer data, it's important to save it as customer entered.

Some examples:
```
yaml column:  `user_meta`
           values: { "author_id" => "213_312_312_"}, { "project_id" => "1001_"}
```