### PR TITLE
Avoid repeated access to Ractor.current

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -24,6 +24,7 @@ module Psych
         super()
         @st = {}
         @ss = ss
+        @load_tags = Psych.load_tags
         @domain_types = Psych.domain_types
         @class_loader = class_loader
         @symbolize_names = symbolize_names
@@ -48,7 +49,7 @@ module Psych
       end
 
       def deserialize o
-        if klass = resolve_class(Psych.load_tags[o.tag])
+        if klass = resolve_class(@load_tags[o.tag])
           instance = klass.allocate
 
           if instance.respond_to?(:init_with)
@@ -128,7 +129,7 @@ module Psych
       end
 
       def visit_Psych_Nodes_Sequence o
-        if klass = resolve_class(Psych.load_tags[o.tag])
+        if klass = resolve_class(@load_tags[o.tag])
           instance = klass.allocate
 
           if instance.respond_to?(:init_with)
@@ -160,8 +161,8 @@ module Psych
       end
 
       def visit_Psych_Nodes_Mapping o
-        if Psych.load_tags[o.tag]
-          return revive(resolve_class(Psych.load_tags[o.tag]), o)
+        if @load_tags[o.tag]
+          return revive(resolve_class(@load_tags[o.tag]), o)
         end
         return revive_hash(register(o, {}), o) unless o.tag
 
@@ -326,6 +327,7 @@ module Psych
       end
 
       private
+
       def register node, object
         @st[node.anchor] = object if node.anchor
         object

--- a/lib/psych/visitors/visitor.rb
+++ b/lib/psych/visitors/visitor.rb
@@ -17,7 +17,7 @@ module Psych
 
       if defined?(Ractor)
         def dispatch
-          Ractor.current[:Psych_Visitors_Visitor] ||= Visitor.dispatch_cache
+          @dispatch_cache ||= (Ractor.current[:Psych_Visitors_Visitor] ||= Visitor.dispatch_cache)
         end
       else
         DISPATCH = dispatch_cache


### PR DESCRIPTION
When profiling our app against Ruby 3.0 I started seeing `2.3%` of the time spent in `Ractor.current` which surprised me:

```
$ stackprof ~/Downloads/stackprof-shopify-boot-production-wall\ \(2\).dump --method Ractor.current
Ractor.current (<internal:ractor>:273)
  samples:  1464 self (2.3%)  /   1464 total (2.3%)
  callers:
     943  (   64.4%)  Psych.config
     521  (   35.6%)  Psych::Visitors::Visitor#dispatch
  code:
        SOURCE UNAVAILABLE
```

It turns out it is called repeatedly to access Psych "globals".

in https://github.com/ruby/psych/commit/d4861854 @marcandre says benchmarking show Ractor locals are only 15% slower than constant access, but that surprises me.

Either way both properties are accessed from `Visitor` instances, and AFAICT these are not shareable, so I think we could simply cache these lookups, in the same way that `Psych.domain_types` is already cached.

Let me know if I missed something.