### PR TITLE
feat: allow scalars and sequences to be styled when dumped

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -509,9 +509,9 @@ module Psych
       def emit_coder c, o
         case c.type
         when :scalar
-          @emitter.scalar c.scalar, nil, c.tag, c.tag.nil?, false, Nodes::Scalar::ANY
+          @emitter.scalar c.scalar, nil, c.tag, c.tag.nil?, false, c.style
         when :seq
-          @emitter.start_sequence nil, c.tag, c.tag.nil?, Nodes::Sequence::BLOCK
+          @emitter.start_sequence nil, c.tag, c.tag.nil?, c.style
           c.seq.each do |thing|
             accept thing
           end


### PR DESCRIPTION
This patch allows `coder.style` to be set uniformly for maps, sequences, and scalars. Previously `coder.style` was ignored for sequences and scalars. Setting `coder.style` allows the author to customize how their document is serialized by `Psych.dump`.

```ruby
# Psych::Nodes::Scalar::PLAIN
# Psych::Nodes::Scalar::SINGLE_QUOTED
# Psych::Nodes::Scalar::DOUBLE_QUOTED
# Psych::Nodes::Scalar::LITERAL
# Psych::Nodes::Scalar::FOLDED
class MyScalar
  def encode_with(coder)
    coder.style = ...
    coder.scalar = ''
  end
end

# Psych::Nodes::Sequence::BLOCK
# Psych::Nodes::Sequence::FLOW
class MySequence
  def encode_with(coder)
    coder.style = ...
    coder.seq = []
  end
end

# Psych::Nodes::Mapping::BLOCK
# Psych::Nodes::Mapping::FLOW
class MyMap
  def encode_with(coder)
    coder.style = ...
    coder.map = {}
  end
end
```

This is a refactor of the work started in https://github.com/ruby/psych/pull/329. I added extra tests to cover the current behavior of other dumps (only five tests fail without the patch) to explore @hkmaly's concerns about needing to change `@style` in `Coder#scalar=`, but no edge cases came up. The constants in question return `0` and `1` and all of the coders output the same for either value. This patch allows `style` to be controlled by the user, and I don't see a reason to override the user's choice when calling `Coder#scalar=`.  Doing so would make the following calls order dependent (even though the serialization appears to be the same):

```ruby
class MyScalar
  def encode_with(coder)
    coder.style = Psych::Nodes::Scalar::PLAIN
    coder.scalar = ''
    # style is 0, Scalar::ANY
    # VS
    coder.scalar = ''
    coder.style = Psych::Nodes::Scalar::PLAIN
    # style is 1, Scalar::PLAIN
  end
end
```