### PR TITLE
Fix custom marshalization with symbolize_names: true

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -339,7 +339,7 @@ module Psych
         list
       end
 
-      def revive_hash hash, o
+      def revive_hash hash, o, tagged= false
         o.children.each_slice(2) { |k,v|
           key = accept(k)
           val = accept(v)
@@ -366,7 +366,7 @@ module Psych
               hash[key] = val
             end
           else
-            if @symbolize_names
+            if !tagged && @symbolize_names
               key = key.to_sym
             elsif !@freeze
               key = deduplicate(key)
@@ -404,7 +404,7 @@ module Psych
 
       def revive klass, node
         s = register(node, klass.allocate)
-        init_with(s, revive_hash({}, node), node)
+        init_with(s, revive_hash({}, node, true), node)
       end
 
       def init_with o, h, node

--- a/test/psych/test_marshalable.rb
+++ b/test/psych/test_marshalable.rb
@@ -51,5 +51,13 @@ module Psych
       assert(PsychCustomMarshalable === loaded)
       assert_equal(2, loaded.foo)
     end
+
+    def test_init_symbolize_names
+      obj = PsychCustomMarshalable.new(1)
+      loaded = Psych.load(Psych.dump(obj), symbolize_names: true)
+
+      assert(PsychCustomMarshalable === loaded)
+      assert_equal(2, loaded.foo)
+    end
   end
 end


### PR DESCRIPTION
Reported to me by @peterthesling.

Repo script
```ruby
require 'psych'
class Foo
  def initialize(bar)
    @bar = bar
  end
  def init_with(coder)
    @bar = coder["bar"]
  end
  def encode_with(coder)
    coder["bar"] = @bar
  end
end
p Psych.load(Psych.dump(Foo.new(42))) # => #<Foo:0x00007fea51a63d88 @bar=42>
p Psych.load(Psych.dump(Foo.new(42)), symbolize_names: true) # => #<Foo:0x00007fea51a625a0 @bar=nil>
```

What happens is that the Hash built to be passed to `init_with` get its keys symbolized, which breaks the `init_with`.

cc @tenderlove 
