### PR TITLE
Fix symbolize_name with non-string keys

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -366,7 +366,7 @@ module Psych
               hash[key] = val
             end
           else
-            if !tagged && @symbolize_names
+            if !tagged && @symbolize_names && key.is_a?(String)
               key = key.to_sym
             elsif !@freeze
               key = deduplicate(key)

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -371,17 +371,18 @@ class TestPsych < Psych::TestCase
     yaml = <<-eoyml
 foo:
   bar: baz
+  1: 2
 hoge:
   - fuga: piyo
     eoyml
 
     result = Psych.load(yaml)
-    assert_equal result, { "foo" => { "bar" => "baz"}, "hoge" => [{ "fuga" => "piyo" }] }
+    assert_equal result, { "foo" => { "bar" => "baz", 1 => 2 }, "hoge" => [{ "fuga" => "piyo" }] }
 
     result = Psych.load(yaml, symbolize_names: true)
-    assert_equal result, { foo: { bar: "baz" }, hoge: [{ fuga: "piyo" }] }
+    assert_equal result, { foo: { bar: "baz", 1 => 2 }, hoge: [{ fuga: "piyo" }] }
 
     result = Psych.safe_load(yaml, symbolize_names: true)
-    assert_equal result, { foo: { bar: "baz" }, hoge: [{ fuga: "piyo" }] }
+    assert_equal result, { foo: { bar: "baz", 1 => 2 }, hoge: [{ fuga: "piyo" }] }
   end
 end


### PR DESCRIPTION
Reported to me by @peterthesling.

Simple repro:

```ruby
>> Psych.load('1: 2', symbolize_names: true)
Traceback (most recent call last):
       16: from /opt/rubies/2.7.2/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
       15: from (irb):3
       14: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych.rb:282:in `load'
       13: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/nodes/node.rb:50:in `to_ruby'
       12: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:35:in `accept'
       11: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/visitor.rb:6:in `accept'
       10: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/visitor.rb:30:in `visit'
        9: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:318:in `visit_Psych_Nodes_Document'
        8: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:35:in `accept'
        7: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/visitor.rb:6:in `accept'
        6: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/visitor.rb:30:in `visit'
        5: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
        4: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:343:in `revive_hash'
        3: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:343:in `each_slice'
        2: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:343:in `each'
        1: from /Users/byroot/.gem/ruby/2.7.2/gems/psych-3.3.1/lib/psych/visitors/to_ruby.rb:370:in `block in revive_hash'
NoMethodError (undefined method `to_sym' for 1:Integer)
Did you mean?  to_s
```

I went all the way back to when the feature was introduced (https://github.com/ruby/psych/commit/88ad4d50) and apparently it was already failing back then. 

cc @tenderlove 