### PR TITLE
CI - YAML: Avoid 3.0 -> "3" conversion

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 3.0, 2.7, 2.6, 2.5, 2.4 ]
+        ruby: [ "3.0", 2.7, 2.6, 2.5, 2.4 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ruby-head, 3.0, 2.7, 2.6, 2.5, 2.4 ]
+        ruby: [ ruby-head, "3.0", 2.7, 2.6, 2.5, 2.4 ]
     steps:
       - name: Install libraries
         run: sudo apt install haveged


### PR DESCRIPTION
This PR changes the CI configuration slightly, to avoid a float-to-string conversion loss of precision - 3.0 could become "3".