### PR TITLE
Some tests fail with libyaml 0.1.7

### DIFF
--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -274,7 +274,7 @@ module Psych
 
     def test_coder_style_scalar_default
       foo = Psych.dump 'some scalar'
-      assert_equal "--- some scalar\n", foo
+      assert_match /\A--- some scalar\n(?:\.\.\.\n)?\z/, foo
     end
 
     def test_coder_style_scalar_any
@@ -282,7 +282,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::ANY,
         tag: nil
-      assert_equal "--- some scalar\n", foo
+      assert_match /\A--- some scalar\n(?:\.\.\.\n)?\z/, foo
     end
 
     def test_coder_style_scalar_plain
@@ -290,7 +290,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::PLAIN,
         tag: nil
-      assert_equal "--- some scalar\n", foo
+      assert_match /\A--- some scalar\n(?:\.\.\.\n)?\z/, foo
     end
 
     def test_coder_style_scalar_single_quoted

--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -216,7 +216,7 @@ module Psych
 
     def test_coder_style_map_default
       foo = Psych.dump a: 1, b: 2
-      assert_equal foo, "---\n:a: 1\n:b: 2\n"
+      assert_equal "---\n:a: 1\n:b: 2\n", foo
     end
 
     def test_coder_style_map_any
@@ -224,7 +224,7 @@ module Psych
         map: {a: 1, b: 2},
         style: Psych::Nodes::Mapping::ANY,
         tag: nil
-      assert_equal foo, "---\n:a: 1\n:b: 2\n"
+      assert_equal "---\n:a: 1\n:b: 2\n", foo
     end
 
     def test_coder_style_map_block
@@ -232,7 +232,7 @@ module Psych
         map: {a: 1, b: 2},
         style: Psych::Nodes::Mapping::BLOCK,
         tag: nil
-      assert_equal foo, "---\n:a: 1\n:b: 2\n"
+      assert_equal "---\n:a: 1\n:b: 2\n", foo
     end
 
     def test_coder_style_map_flow
@@ -240,12 +240,12 @@ module Psych
         map: { a: 1, b: 2 },
         style: Psych::Nodes::Mapping::FLOW,
         tag: nil
-      assert_equal foo, "--- {! ':a': 1, ! ':b': 2}\n"
+      assert_equal "--- {! ':a': 1, ! ':b': 2}\n", foo
     end
 
     def test_coder_style_seq_default
       foo = Psych.dump [ 1, 2, 3 ]
-      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
+      assert_equal "---\n- 1\n- 2\n- 3\n", foo
     end
 
     def test_coder_style_seq_any
@@ -253,7 +253,7 @@ module Psych
         seq: [ 1, 2, 3 ],
         style: Psych::Nodes::Sequence::ANY,
         tag: nil
-      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
+      assert_equal "---\n- 1\n- 2\n- 3\n", foo
     end
 
     def test_coder_style_seq_block
@@ -261,7 +261,7 @@ module Psych
         seq: [ 1, 2, 3 ],
         style: Psych::Nodes::Sequence::BLOCK,
         tag: nil
-      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
+      assert_equal "---\n- 1\n- 2\n- 3\n", foo
     end
 
     def test_coder_style_seq_flow
@@ -269,12 +269,12 @@ module Psych
         seq: [ 1, 2, 3 ],
         style: Psych::Nodes::Sequence::FLOW,
         tag: nil
-      assert_equal foo, "--- [1, 2, 3]\n"
+      assert_equal "--- [1, 2, 3]\n", foo
     end
 
     def test_coder_style_scalar_default
       foo = Psych.dump 'some scalar'
-      assert_equal foo, "--- some scalar\n"
+      assert_equal "--- some scalar\n", foo
     end
 
     def test_coder_style_scalar_any
@@ -282,7 +282,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::ANY,
         tag: nil
-      assert_equal foo, "--- some scalar\n"
+      assert_equal "--- some scalar\n", foo
     end
 
     def test_coder_style_scalar_plain
@@ -290,7 +290,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::PLAIN,
         tag: nil
-      assert_equal foo, "--- some scalar\n"
+      assert_equal "--- some scalar\n", foo
     end
 
     def test_coder_style_scalar_single_quoted
@@ -298,7 +298,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::SINGLE_QUOTED,
         tag: nil
-      assert_equal foo, "--- ! 'some scalar'\n"
+      assert_equal "--- ! 'some scalar'\n", foo
     end
 
     def test_coder_style_scalar_double_quoted
@@ -306,7 +306,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::DOUBLE_QUOTED,
         tag: nil
-      assert_equal foo, %Q'--- ! "some scalar"\n'
+      assert_equal %Q'--- ! "some scalar"\n', foo
     end
 
     def test_coder_style_scalar_literal
@@ -314,7 +314,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::LITERAL,
         tag: nil
-      assert_equal foo, "--- ! |-\n  some scalar\n"
+      assert_equal "--- ! |-\n  some scalar\n", foo
     end
 
     def test_coder_style_scalar_folded
@@ -322,7 +322,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::FOLDED,
         tag: nil
-      assert_equal foo, "--- ! >-\n  some scalar\n"
+      assert_equal "--- ! >-\n  some scalar\n", foo
     end
   end
 end


### PR DESCRIPTION
http://rubyci.s3.amazonaws.com/ubuntu1804/ruby-master/log/20210517T033003Z.fail.html.gz
```
  1) Failure:
Psych::TestCoder#test_coder_style_scalar_any [/home/chkbuild/chkbuild/tmp/build/20210517T043003Z/ruby/test/psych/test_coder.rb:285]:
<"--- some scalar\n" + "...\n"> expected but was
<"--- some scalar\n">.

  2) Failure:
Psych::TestCoder#test_coder_style_scalar_default [/home/chkbuild/chkbuild/tmp/build/20210517T043003Z/ruby/test/psych/test_coder.rb:277]:
<"--- some scalar\n" + "...\n"> expected but was
<"--- some scalar\n">.

  3) Failure:
Psych::TestCoder#test_coder_style_scalar_plain [/home/chkbuild/chkbuild/tmp/build/20210517T043003Z/ruby/test/psych/test_coder.rb:293]:
<"--- some scalar\n" + "...\n"> expected but was
<"--- some scalar\n">.
```