### PR TITLE
Implement YAML.safe_dump to make safe_load more usable.

### DIFF
--- a/lib/psych/class_loader.rb
+++ b/lib/psych/class_loader.rb
@@ -86,7 +86,7 @@ module Psych
         if @symbols.include? sym
           super
         else
-          raise DisallowedClass, 'Symbol'
+          raise DisallowedClass.new('load', 'Symbol')
         end
       end
 
@@ -96,7 +96,7 @@ module Psych
         if @classes.include? klassname
           super
         else
-          raise DisallowedClass, klassname
+          raise DisallowedClass.new('load', klassname)
         end
       end
     end

--- a/lib/psych/exception.rb
+++ b/lib/psych/exception.rb
@@ -7,8 +7,8 @@ module Psych
   end
 
   class DisallowedClass < Exception
-    def initialize klass_name
-      super "Tried to load unspecified class: #{klass_name}"
+    def initialize action, klass_name
+      super "Tried to #{action} unspecified class: #{klass_name}"
     end
   end
 end


### PR DESCRIPTION
Ref: https://github.com/ruby/psych/pull/487

In case where Psych is used as a two way serializers, e.g. to serialize some cache or config, it is preferable to have the same restrictions on both load and dump.

Otherwise you might dump and persist some objects payloads that you later won't be able to read.

cc @pixeltrix as we discussed this earlier today. cc @tenderlove because https://github.com/ruby/psych/pull/487

I also think that this hints at having some kind of "parser" instance that could hold the configuration, e.g.:

```ruby
ConfigYamler = YAML.new(permitted_classes: [...])
ConfigYamler.load(ConfigYamler.dump(some_object))
```

This could even allow to expose `YAML::Safe`, `YAML::Unsafe` as more usable shorthands.

NB: The dump might need to restrict aliases as well, but I need to have a deeper look to see how that could be possible.