### PR TITLE
cleanup: Avoid "warning: ambiguity in regexp" in test

### DIFF
--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -274,7 +274,7 @@ module Psych
 
     def test_coder_style_scalar_default
       foo = Psych.dump 'some scalar'
-      assert_match /\A--- some scalar\n(?:\.\.\.\n)?\z/, foo
+      assert_match %r{\A--- some scalar\n(?:\.\.\.\n)?\z}, foo
     end
 
     def test_coder_style_scalar_any
@@ -282,7 +282,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::ANY,
         tag: nil
-      assert_match /\A--- some scalar\n(?:\.\.\.\n)?\z/, foo
+      assert_match %r{\A--- some scalar\n(?:\.\.\.\n)?\z}, foo
     end
 
     def test_coder_style_scalar_plain
@@ -290,7 +290,7 @@ module Psych
         scalar: 'some scalar',
         style: Psych::Nodes::Scalar::PLAIN,
         tag: nil
-      assert_match /\A--- some scalar\n(?:\.\.\.\n)?\z/, foo
+      assert_match %r{\A--- some scalar\n(?:\.\.\.\n)?\z}, foo
     end
 
     def test_coder_style_scalar_single_quoted


### PR DESCRIPTION
This PR avoid this warning which was output during tests:

> /home/runner/work/psych/psych/test/psych/test_coder.rb:277: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator

Solved by: using other delimiters for regular expressions.