### PR TITLE
require 'delegate' explicitly

### DIFF
--- a/test/psych/visitors/test_yaml_tree.rb
+++ b/test/psych/visitors/test_yaml_tree.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'psych/helper'
+require 'delegate'
 
 module Psych
   module Visitors


### PR DESCRIPTION
```test/psych/visitors/test_yaml_tree.rb``` depends on the delegator, but it doesn't have to be available yet, especially if we run the test separately or concurrently

right now the test suite is green because the code is actually loaded sooner in a different test
```require 'delegate'```
https://github.com/ruby/psych/blob/master/test/psych/test_marshalable.rb#L3

this change fixes the racy behavior