### PR TITLE
Update ScalarScanner#tokenize pattern to use [:alpha:] instead of A-Za-z

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -34,7 +34,7 @@ module Psych
 
       # Check for a String type, being careful not to get caught by hash keys, hex values, and
       # special floats (e.g., -.inf).
-      if string.match?(/^[^\d\.:-]?[A-Za-z_\s!@#\$%\^&\*\(\)\{\}\<\>\|\/\\~;=]+/) || string.match?(/\n/)
+      if string.match?(%r{^[^\d.:-]?[[:alpha:]_\s!@#$%\^&*(){}<>|/\\~;=]+}) || string.match?(/\n/)
         return string if string.length > 5
 
         if string.match?(/^[^ytonf~]/i)

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -150,7 +150,7 @@ module Psych
       assert_equal 1, ascii.match_call_count
     end
 
-    def tests_scan_unicode_matches_quickly
+    def test_scan_unicode_matches_quickly
       unicode = MatchCallCounter.new('鳥かご関連用品')
       ss.tokenize(unicode)
       assert_equal 1, unicode.match_call_count

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -133,5 +133,27 @@ module Psych
       assert_equal 0x123456789abcdef, ss.tokenize('0x_12_,34,_56,_789abcdef')
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef__')
     end
+
+    class MatchCallCounter < String
+      attr_reader :match_call_count
+
+      def match?(pat)
+        @match_call_count ||= 0
+        @match_call_count += 1
+        super
+      end
+    end
+
+    def test_scan_ascii_matches_quickly
+      ascii = MatchCallCounter.new('abcdefghijklmnopqrstuvwxyz')
+      ss.tokenize(ascii)
+      assert_equal 1, ascii.match_call_count
+    end
+
+    def tests_scan_unicode_matches_quickly
+      unicode = MatchCallCounter.new('鳥かご関連用品')
+      ss.tokenize(unicode)
+      assert_equal 1, unicode.match_call_count
+    end
   end
 end


### PR DESCRIPTION
Strings of non-latin characters were hitting all 11 branches of the conditional in `#tokenize` before being spit back out, leading to really bad performance for `Object#to_yaml` calls on unicode translations.

Here's how long it took using `A-Za-z`
```
locale  yaml_time
cs	0.3436040370725095
da	0.2721987213008106
de	0.4194269562140107
es	0.2533304113894701
fi	0.21773323602974415
fr	0.297291514929384
it	0.08707034215331078
ja	1.808898635674268
ko	2.4477550918236375
nb	0.2407214930281043
nl	0.08863845886662602
pl	0.2930908463895321
pt-BR	0.2803854998201132
pt-PT	0.29105220874771476
sv	0.2872147047892213
th	1.9660059828311205
tr	0.3638794207945466
vi	0.4239793550223112
zh-CN	2.3702405453659594
zh-TW	2.2211534748785198

Finished in 17.35736s
```
And here's the run time using `[:alpha:]`
```
locale  yaml_time
cs	0.4703981657512486
da	0.4865010338835418
de	0.35174005618318915
es	0.3446801542304456
fi	0.2845723726786673
fr	0.405109120067209
it	0.09236077778041363
ja	0.39286558190360665
ko	0.4466092209331691
nb	0.30534958792850375
nl	0.0843697632662952
pl	0.3951657977886498
pt-BR	0.3883421439677477
pt-PT	0.3656166330911219
sv	0.4281684779562056
th	0.4255535639822483
tr	0.41262169694527984
vi	0.4109211592003703
zh-CN	0.38979955576360226
zh-TW	0.39605427207425237

Finished in 9.73973s
```