### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'psych/versions'
+require_relative 'psych/versions'
 case RUBY_ENGINE
 when 'jruby'
-  require 'psych_jars'
+  require_relative 'psych_jars'
   if JRuby::Util.respond_to?(:load_ext)
     JRuby::Util.load_ext('org.jruby.ext.psych.PsychLibrary')
   else
@@ -12,21 +12,21 @@ when 'jruby'
 else
   require 'psych.so'
 end
-require 'psych/nodes'
-require 'psych/streaming'
-require 'psych/visitors'
-require 'psych/handler'
-require 'psych/tree_builder'
-require 'psych/parser'
-require 'psych/omap'
-require 'psych/set'
-require 'psych/coder'
-require 'psych/core_ext'
-require 'psych/stream'
-require 'psych/json/tree_builder'
-require 'psych/json/stream'
-require 'psych/handlers/document_stream'
-require 'psych/class_loader'
+require_relative 'psych/nodes'
+require_relative 'psych/streaming'
+require_relative 'psych/visitors'
+require_relative 'psych/handler'
+require_relative 'psych/tree_builder'
+require_relative 'psych/parser'
+require_relative 'psych/omap'
+require_relative 'psych/set'
+require_relative 'psych/coder'
+require_relative 'psych/core_ext'
+require_relative 'psych/stream'
+require_relative 'psych/json/tree_builder'
+require_relative 'psych/json/stream'
+require_relative 'psych/handlers/document_stream'
+require_relative 'psych/class_loader'
 
 ###
 # = Overview

--- a/lib/psych/class_loader.rb
+++ b/lib/psych/class_loader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'psych/omap'
-require 'psych/set'
+require_relative 'omap'
+require_relative 'set'
 
 module Psych
   class ClassLoader # :nodoc:

--- a/lib/psych/core_ext.rb
+++ b/lib/psych/core_ext.rb
@@ -15,5 +15,5 @@ class Object
 end
 
 if defined?(::IRB)
-  require 'psych/y'
+  require_relative 'y'
 end

--- a/lib/psych/handlers/document_stream.rb
+++ b/lib/psych/handlers/document_stream.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'psych/tree_builder'
+require_relative '../tree_builder'
 
 module Psych
   module Handlers

--- a/lib/psych/handlers/recorder.rb
+++ b/lib/psych/handlers/recorder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'psych/handler'
+require_relative '../handler'
 
 module Psych
   module Handlers

--- a/lib/psych/json/stream.rb
+++ b/lib/psych/json/stream.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'psych/json/ruby_events'
-require 'psych/json/yaml_events'
+require_relative 'ruby_events'
+require_relative 'yaml_events'
 
 module Psych
   module JSON

--- a/lib/psych/json/tree_builder.rb
+++ b/lib/psych/json/tree_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'psych/json/yaml_events'
+require_relative 'yaml_events'
 
 module Psych
   module JSON

--- a/lib/psych/nodes.rb
+++ b/lib/psych/nodes.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-require 'psych/nodes/node'
-require 'psych/nodes/stream'
-require 'psych/nodes/document'
-require 'psych/nodes/sequence'
-require 'psych/nodes/scalar'
-require 'psych/nodes/mapping'
-require 'psych/nodes/alias'
+require_relative 'nodes/node'
+require_relative 'nodes/stream'
+require_relative 'nodes/document'
+require_relative 'nodes/sequence'
+require_relative 'nodes/scalar'
+require_relative 'nodes/mapping'
+require_relative 'nodes/alias'
 
 module Psych
   ###

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'stringio'
-require 'psych/class_loader'
-require 'psych/scalar_scanner'
+require_relative '../class_loader'
+require_relative '../scalar_scanner'
 
 module Psych
   module Nodes

--- a/lib/psych/syntax_error.rb
+++ b/lib/psych/syntax_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'psych/exception'
+require_relative 'exception'
 
 module Psych
   class SyntaxError < Psych::Exception

--- a/lib/psych/tree_builder.rb
+++ b/lib/psych/tree_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'psych/handler'
+require_relative 'handler'
 
 module Psych
   ###

--- a/lib/psych/visitors.rb
+++ b/lib/psych/visitors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'psych/visitors/visitor'
-require 'psych/visitors/to_ruby'
-require 'psych/visitors/emitter'
-require 'psych/visitors/yaml_tree'
-require 'psych/visitors/json_tree'
-require 'psych/visitors/depth_first'
+require_relative 'visitors/visitor'
+require_relative 'visitors/to_ruby'
+require_relative 'visitors/emitter'
+require_relative 'visitors/yaml_tree'
+require_relative 'visitors/json_tree'
+require_relative 'visitors/depth_first'

--- a/lib/psych/visitors/json_tree.rb
+++ b/lib/psych/visitors/json_tree.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'psych/json/ruby_events'
+require_relative '../json/ruby_events'
 
 module Psych
   module Visitors

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'psych/scalar_scanner'
-require 'psych/class_loader'
-require 'psych/exception'
+require_relative '../scalar_scanner'
+require_relative '../class_loader'
+require_relative '../exception'
 
 unless defined?(Regexp::NOENCODING)
   Regexp::NOENCODING = 32

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'psych/tree_builder'
-require 'psych/scalar_scanner'
-require 'psych/class_loader'
+require_relative '../tree_builder'
+require_relative '../scalar_scanner'
+require_relative '../class_loader'
 
 module Psych
   module Visitors


### PR DESCRIPTION
I received [an issue](https://github.com/rubygems/rubygems/issues/4961) in the rubygems repository with the following error and backtrace:

```
ArgumentError: unknown keywords: :symbolize_names, :freeze
  /usr/local/lib/ruby/2.7/psych/visitors/to_ruby.rb:23:in `initialize'
  /usr/local/AC-TESTING/marlpier/disgorge/releases/20211005-092406/analyst-console-escalations-1.2.15.1.130/vendor/bundle/ruby/2.7/gems/psych-3.2.0/lib/psych.rb:355:in `new'
  /usr/local/AC-TESTING/marlpier/disgorge/releases/20211005-092406/analyst-console-escalations-1.2.15.1.130/vendor/bundle/ruby/2.7/gems/psych-3.2.0/lib/psych.rb:355:in `safe_load'
(...)
```

The actual culprit remains unclear, but we can avoid this kind of jump from one version of a gem to a different copy (and version) of the same gem by using `require_relative` for internal requires.