### PR TITLE
Only skip specific failures on JRuby instead of ignoring the whole CI feedback

### DIFF
--- a/.github/workflows/ubuntu-jruby.yml
+++ b/.github/workflows/ubuntu-jruby.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
-        run: gem install ruby-maven power_assert test-unit rake-compiler 
+        run: bundle install --jobs 1
       - name: compile
-        run: rake compile
+        run: bundle exec rake compile
       - name: test
         continue-on-error: true
-        run: rake test
+        run: bundle exec rake test

--- a/.github/workflows/ubuntu-jruby.yml
+++ b/.github/workflows/ubuntu-jruby.yml
@@ -20,5 +20,4 @@ jobs:
       - name: compile
         run: bundle exec rake compile
       - name: test
-        continue-on-error: true
         run: bundle exec rake test

--- a/test/psych/test_coder.rb
+++ b/test/psych/test_coder.rb
@@ -220,6 +220,8 @@ module Psych
     end
 
     def test_coder_style_map_any
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       foo = Psych.dump CustomEncode.new \
         map: {a: 1, b: 2},
         style: Psych::Nodes::Mapping::ANY,
@@ -228,6 +230,8 @@ module Psych
     end
 
     def test_coder_style_map_block
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       foo = Psych.dump CustomEncode.new \
         map: {a: 1, b: 2},
         style: Psych::Nodes::Mapping::BLOCK,
@@ -236,6 +240,8 @@ module Psych
     end
 
     def test_coder_style_map_flow
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       foo = Psych.dump CustomEncode.new \
         map: { a: 1, b: 2 },
         style: Psych::Nodes::Mapping::FLOW,

--- a/test/psych/test_encoding.rb
+++ b/test/psych/test_encoding.rb
@@ -119,6 +119,8 @@ module Psych
     end
 
     def test_emit_alias
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       @emitter.start_stream Psych::Parser::UTF8
       @emitter.start_document [], [], true
       e = assert_raise(RuntimeError) do
@@ -151,6 +153,7 @@ module Psych
       @emitter.end_mapping
       @emitter.end_document false
       @emitter.end_stream
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
 
       @parser.parse @buffer.string
       assert_encodings @utf8, @handler.strings
@@ -170,6 +173,7 @@ module Psych
       @emitter.end_sequence
       @emitter.end_document false
       @emitter.end_stream
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
 
       @parser.parse @buffer.string
       assert_encodings @utf8, @handler.strings
@@ -187,6 +191,7 @@ module Psych
       @emitter.scalar 'foo', nil, nil, true, false, Nodes::Scalar::ANY
       @emitter.end_document false
       @emitter.end_stream
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
 
       @parser.parse @buffer.string
       assert_encodings @utf8, @handler.strings
@@ -263,6 +268,8 @@ module Psych
     end
 
     def test_dump_non_ascii_string_to_file
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       Tempfile.create(['utf8', 'yml'], :encoding => 'UTF-8') do |t|
         h = {'one' => 'いち'}
         Psych.dump(h, t)

--- a/test/psych/test_parser.rb
+++ b/test/psych/test_parser.rb
@@ -85,6 +85,8 @@ module Psych
 
     def test_line_numbers
       assert_equal 0, @parser.mark.line
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       @parser.parse "---\n- hello\n- world"
       line_calls = @handler.marks.map(&:line).zip(@handler.calls.map(&:first))
       assert_equal [
@@ -110,6 +112,8 @@ module Psych
 
     def test_column_numbers
       assert_equal 0, @parser.mark.column
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       @parser.parse "---\n- hello\n- world"
       col_calls = @handler.marks.map(&:column).zip(@handler.calls.map(&:first))
       assert_equal [
@@ -135,6 +139,8 @@ module Psych
 
     def test_index_numbers
       assert_equal 0, @parser.mark.index
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       @parser.parse "---\n- hello\n- world"
       idx_calls = @handler.marks.map(&:index).zip(@handler.calls.map(&:first))
       assert_equal [
@@ -352,6 +358,8 @@ module Psych
     end
 
     def test_event_location
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
       @parser.parse "foo:\n" \
                     "  barbaz: [1, 2]"
 


### PR DESCRIPTION
This PR is just some experiment to proof that https://github.com/jruby/ruby-maven/pull/2 fixes:

* Issue reported at https://github.com/ruby/psych/issues/479#issuecomment-785469484, where jruby tests fail to even get started in CI (`bundle install` fails).
* https://github.com/ruby/psych/issues/520.
* https://github.com/jruby/ruby-maven/issues/3.
* https://github.com/rubygems/rubygems/issues/4685.