### PR TITLE
Add stringio as a dependency.

### DIFF
--- a/psych.gemspec
+++ b/psych.gemspec
@@ -64,4 +64,6 @@ DESCRIPTION
   else
     s.extensions = ["ext/psych/extconf.rb"]
   end
+
+  s.add_dependency 'stringio'
 end


### PR DESCRIPTION
Hello!

During fixing rubygems build against ruby-trunk I have found out that psych requires `stringio`, which is currently default gem and it should be reflected as a dependency.

https://github.com/ruby/psych/blob/69a713f8601a17bcadb657719af689541f273986/lib/psych/nodes/node.rb#L2

Does it make sense? Or is there any reason to not make it dependency?