### PR TITLE
Don't require `strscan` unnecessarily

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'strscan'
 
 module Psych
   ###


### PR DESCRIPTION
It does not seem needed, and it's causing issues on Windows when uninstalling `strscan`, because strscan's shared library being used when RubyGems tries to remove it (because its loaded through Psych, which RubyGems uses for loading configuration).

Partially fixes https://github.com/rubygems/rubygems/issues/5274.