### PR TITLE
Update Psych::VERSION to 4.0.4.dev, Add Ruby 3.1 & windows-2022 to CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,3 +21,6 @@ jobs:
         run: bundle install
       - name: Run test
         run: rake
+      - name: Install gem
+        run: rake install
+        if: ${{ matrix.ruby != 'head' }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,4 +23,4 @@ jobs:
         run: rake
       - name: Install gem
         run: rake install
-        if: ${{ matrix.ruby != 'head' && matrix.ruby != '3.1' }}
+        if: ${{ matrix.ruby != 'head' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,37 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ mingw, mswin, 3.1, "3.0", 2.7, 2.6, 2.5, 2.4 ]
+        ruby: [ ucrt, mingw, mswin, 3.1, "3.0", 2.7, 2.6, 2.5, 2.4 ]
+        os: [ windows-latest ]
     steps:
       - uses: actions/checkout@v3
-      - name: Install libraries with vcpkg
-        id: vcpkg
-        run: |
-          vcpkg --triplet x64-windows install libyaml
-        if: ${{ matrix.ruby == 'mswin' }}
-      - name: link libraries
-        run: |
-          for %%I in (C:\vcpkg\installed\x64-windows\bin\*.dll) do (
-            mklink %%~nxI %%I
-          )
-        if: ${{ steps.vcpkg.conclusion == 'success' }}
       - name: Set up Ruby
         uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          mingw: _upgrade_ libyaml
+          vcpkg: libyaml
       - name: Install dependencies
         run: bundle install
-      - name: Compile
-        run: rake compile -- --with-libyaml-dir=C:/vcpkg/installed/x64-windows
-        if: ${{ matrix.ruby == 'mswin' }}
       - name: Run test
         run: rake
-
-defaults:
-  run:
-    shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,3 +21,8 @@ jobs:
         run: bundle install
       - name: Run test
         run: rake
+      - name: Install gem
+        run: rake install
+        # use all possible head strings
+        if: |
+          !(contains('ucrt mingw mswin head', matrix.ruby))

--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -2,7 +2,7 @@
 
 module Psych
   # The version of Psych you are using
-  VERSION = '4.0.3'
+  VERSION = '4.0.4.dev'
 
   if RUBY_ENGINE == 'jruby'
     DEFAULT_SNAKEYAML_VERSION = '1.28'.freeze


### PR DESCRIPTION
Update Psych::VERSION to 4.0.4.dev

Actions:
1. Test with Ruby 3.1
2. Remove MSP-Greg/setup-ruby-pkgs from Windows CI, use ruby/setup-ruby
3. Use numeric OS designation instead of 'latest'
4. Add `Install gem` step to macos & windows CI
5. Change to windows-2022 image

Re #2, in Actions CI, MSP-Greg/setup-ruby-pkgs can be replaced with ruby/setup-ruby only when using windows-2022 and Ruby versions 2.4 thru master and if the required 'packages' match what is required to build Ruby.  There is one exception, Ruby 2.4 and OpenSSL, as Windows Ruby 2.4 uses OpenSSL 1.0.2, while Ruby 2.5 and later use OpenSSL 1.1.1.
