### PR TITLE
Add strict_integer option to parse numbers with commas as strings

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -268,10 +268,10 @@ module Psych
   # YAML documents that are supplied via user input.  Instead, please use the
   # load method or the safe_load method.
   #
-  def self.unsafe_load yaml, filename: nil, fallback: false, symbolize_names: false, freeze: false
+  def self.unsafe_load yaml, filename: nil, fallback: false, symbolize_names: false, freeze: false, strict_integer: false
     result = parse(yaml, filename: filename)
     return fallback unless result
-    result.to_ruby(symbolize_names: symbolize_names, freeze: freeze)
+    result.to_ruby(symbolize_names: symbolize_names, freeze: freeze, strict_integer: strict_integer)
   end
   class << self; alias :load :unsafe_load; end
 
@@ -320,13 +320,13 @@ module Psych
   #   Psych.safe_load("---\n foo: bar")                         # => {"foo"=>"bar"}
   #   Psych.safe_load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
-  def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false
+  def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
     result = parse(yaml, filename: filename)
     return fallback unless result
 
     class_loader = ClassLoader::Restricted.new(permitted_classes.map(&:to_s),
                                                permitted_symbols.map(&:to_s))
-    scanner      = ScalarScanner.new class_loader
+    scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer
     visitor = if aliases
                 Visitors::ToRuby.new scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze
               else
@@ -366,14 +366,15 @@ module Psych
   # Raises a TypeError when `yaml` parameter is NilClass.  This method is
   # similar to `safe_load` except that `Symbol` objects are allowed by default.
   #
-  def self.load yaml, permitted_classes: [Symbol], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false
+  def self.load yaml, permitted_classes: [Symbol], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
     safe_load yaml, permitted_classes: permitted_classes,
                     permitted_symbols: permitted_symbols,
                     aliases: aliases,
                     filename: filename,
                     fallback: fallback,
                     symbolize_names: symbolize_names,
-                    freeze: freeze
+                    freeze: freeze,
+                    strict_integer: strict_integer
   end
 
   ###

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -46,8 +46,8 @@ module Psych
       # Convert this node to Ruby.
       #
       # See also Psych::Visitors::ToRuby
-      def to_ruby(symbolize_names: false, freeze: false)
-        Visitors::ToRuby.create(symbolize_names: symbolize_names, freeze: freeze).accept(self)
+      def to_ruby(symbolize_names: false, freeze: false, strict_integer: false)
+        Visitors::ToRuby.create(symbolize_names: symbolize_names, freeze: freeze, strict_integer: strict_integer).accept(self)
       end
       alias :transform :to_ruby
 

--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -12,24 +12,32 @@ module Psych
     FLOAT = /^(?:[-+]?([0-9][0-9_,]*)?\.[0-9]*([eE][-+][0-9]+)?(?# base 10))$/x
 
     # Taken from http://yaml.org/type/int.html
-    INTEGER = /^(?:[-+]?0b[0-1_,]+                        (?# base 2)
-                  |[-+]?0[0-7_,]+                         (?# base 8)
-                  |[-+]?(?:0|[1-9](?:[0-9]|,[0-9]|_[0-9])*) (?# base 10)
-                  |[-+]?0x[0-9a-fA-F_,]+                  (?# base 16))$/x
+    INTEGER_STRICT = /^(?:[-+]?0b[0-1_]+                  (?# base 2)
+                         |[-+]?0[0-7_]+                   (?# base 8)
+                         |[-+]?(0|[1-9][0-9_]*)           (?# base 10)
+                         |[-+]?0x[0-9a-fA-F_]+            (?# base 16))$/x
+
+    # Same as above, but allows commas.
+    # Not to YML spec, but kept for backwards compatibility
+    INTEGER_LEGACY = /^(?:[-+]?0b[0-1_,]+                        (?# base 2)
+                         |[-+]?0[0-7_,]+                         (?# base 8)
+                         |[-+]?(?:0|[1-9](?:[0-9]|,[0-9]|_[0-9])*) (?# base 10)
+                         |[-+]?0x[0-9a-fA-F_,]+                  (?# base 16))$/x
 
     attr_reader :class_loader
 
     # Create a new scanner
-    def initialize class_loader
+    def initialize class_loader, strict_integer: false
       @symbol_cache = {}
       @class_loader = class_loader
+      @strict_integer = strict_integer
     end
 
     # Tokenize +string+ returning the Ruby object
     def tokenize string
       return nil if string.empty?
       return @symbol_cache[string] if @symbol_cache.key?(string)
-
+      integer_regex = @strict_integer ? INTEGER_STRICT : INTEGER_LEGACY
       # Check for a String type, being careful not to get caught by hash keys, hex values, and
       # special floats (e.g., -.inf).
       if string.match?(%r{^[^\d.:-]?[[:alpha:]_\s!@#$%\^&*(){}<>|/\\~;=]+}) || string.match?(/\n/)
@@ -89,7 +97,7 @@ module Psych
         else
           Float(string.gsub(/[,_]|\.([Ee]|$)/, '\1'))
         end
-      elsif string.match?(INTEGER)
+      elsif string.match?(integer_regex)
         parse_int string
       else
         string

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -12,9 +12,9 @@ module Psych
     ###
     # This class walks a YAML AST, converting each node to Ruby
     class ToRuby < Psych::Visitors::Visitor
-      def self.create(symbolize_names: false, freeze: false)
+      def self.create(symbolize_names: false, freeze: false, strict_integer: false)
         class_loader = ClassLoader.new
-        scanner      = ScalarScanner.new class_loader
+        scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer
         new(scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze)
       end
 

--- a/test/psych/test_numeric.rb
+++ b/test/psych/test_numeric.rb
@@ -43,5 +43,16 @@ module Psych
       str = Psych.load('--- 1.1.1')
       assert_equal '1.1.1', str
     end
+
+    # This behavior is not to YML spec, but is kept for backwards compatibility
+    def test_string_with_commas
+      number = Psych.load('--- 12,34,56')
+      assert_equal 123456, number
+    end
+
+    def test_string_with_commas_with_strict_integer
+      str = Psych.load('--- 12,34,56', strict_integer: true)
+      assert_equal '12,34,56', str
+    end
   end
 end

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -149,6 +149,31 @@ module Psych
       assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef__')
     end
 
+    def test_scan_strict_int_commas_and_underscores
+      # this test is to ensure adherance to YML spec using the 'strict_integer' option
+      scanner = Psych::ScalarScanner.new ClassLoader.new, strict_integer: true
+      assert_equal 123_456_789, scanner.tokenize('123_456_789')
+      assert_equal '123,456,789', scanner.tokenize('123,456,789')
+      assert_equal '1_2,3,4_5,6_789', scanner.tokenize('1_2,3,4_5,6_789')
+
+      assert_equal 1, scanner.tokenize('1')
+      assert_equal 1, scanner.tokenize('+1')
+      assert_equal(-1, scanner.tokenize('-1'))
+
+      assert_equal 0b010101010, scanner.tokenize('0b010101010')
+      assert_equal 0b010101010, scanner.tokenize('0b01_01_01_010')
+      assert_equal '0b0,1_0,1_,0,1_01,0', scanner.tokenize('0b0,1_0,1_,0,1_01,0')
+
+      assert_equal 01234567, scanner.tokenize('01234567')
+      assert_equal '0_,,,1_2,_34567', scanner.tokenize('0_,,,1_2,_34567')
+
+      assert_equal 0x123456789abcdef, scanner.tokenize('0x123456789abcdef')
+      assert_equal 0x123456789abcdef, scanner.tokenize('0x12_34_56_789abcdef')
+      assert_equal '0x12_,34,_56,_789abcdef', scanner.tokenize('0x12_,34,_56,_789abcdef')
+      assert_equal '0x_12_,34,_56,_789abcdef', scanner.tokenize('0x_12_,34,_56,_789abcdef')
+      assert_equal '0x12_,34,_56,_789abcdef__', scanner.tokenize('0x12_,34,_56,_789abcdef__')
+    end
+
     def test_scan_dot
       assert_equal '.', ss.tokenize('.')
     end


### PR DESCRIPTION
Addresses #273

This PR introduces a `strict_integer` option to the load/parsing methods, allowing for closer adherence to the YML spec, which specifies that numbers including commas should be parsed as strings.  More details in the above linked issue.

