### PR TITLE
Remove alias of load to unsafe_load

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -273,7 +273,6 @@ module Psych
     return fallback unless result
     result.to_ruby(symbolize_names: symbolize_names, freeze: freeze)
   end
-  class << self; alias :load :unsafe_load; end
 
   ###
   # Safely load the yaml string in +yaml+.  By default, only the following


### PR DESCRIPTION
There are method [`Psych.load`](https://github.com/ruby/psych/blob/ba203f19c03763e6f7b7b97a76ce89e3ae488a6f/lib/psych.rb#L369) and [alias `load`](https://github.com/ruby/psych/blob/ba203f19c03763e6f7b7b97a76ce89e3ae488a6f/lib/psych.rb#L276) to `unsafe_load` exists in same time.

According the code `load` is now decorate `safe_load`.

Rdoc generates docs base on alias: https://docs.ruby-lang.org/en/3.1/Psych.html#method-c-load

![image](https://user-images.githubusercontent.com/21104/150180845-8b8f5b51-b1ae-464e-8c0f-001b4463428a.png)


The same versions exists in ruby https://github.com/ruby/ruby/blob/fb4df44d1670e9d25aef6b235a7281199a177edb/ext/psych/lib/psych.rb#L276

I assume the changes should first made here. Let me know if it is correct.