### PR TITLE
Make a static library from PIC object files

### DIFF
--- a/ext/psych/depend
+++ b/ext/psych/depend
@@ -2,8 +2,12 @@ $(TARGET_SO): $(LIBYAML)
 
 libyaml $(LIBYAML):
 	cd libyaml && $(MAKE)
+	$(AR) $(ARFLAGS) $(LIBYAML) $(LIBYAML_OBJDIR)/*.$(OBJEXT)
+	$(RANLIB) $(LIBYAML)
+
 clean-so::
 	-cd libyaml && $(MAKE) clean
+
 distclean-so::
 	-cd libyaml && $(MAKE) distclean
 	-$(Q)$(RMDIRS) libyaml/* libyaml


### PR DESCRIPTION
On some platforms, PIC and non-PIC code are incompatible and the latter cannot be used for shared objects.