### PR TITLE
Use the latest config.sub and config.guess when building from source

### DIFF
--- a/ext/psych/extconf.rb
+++ b/ext/psych/extconf.rb
@@ -20,12 +20,22 @@ if yaml_source == true
   yaml_source = Dir.glob("#{$srcdir}/yaml{,-*}/").max_by {|n| File.basename(n).scan(/\d+/).map(&:to_i)}
   unless yaml_source
     require_relative '../../tool/extlibs.rb'
-    extlibs = ExtLibs.new(cache_dir: File.expand_path("../../tmp/download_cache", $srcdir))
+    cache_dir = File.expand_path("../../tmp/download_cache", $srcdir)
+    extlibs = ExtLibs.new(cache_dir: cache_dir)
     unless extlibs.process_under($srcdir)
       raise "failed to download libyaml source"
     end
     yaml_source, = Dir.glob("#{$srcdir}/yaml-*/")
     raise "libyaml not found" unless yaml_source
+
+    config_dir = File.join(File.expand_path(yaml_source), "config")
+    config_tools = ["config.guess", "config.sub"]
+    puts("Downloading latest #{config_tools.join(" ")}")
+    config_tools.each do |tool|
+      # remove bundled old config tools
+      rm_f File.join(config_dir, tool)
+      Downloader::GNU.download(tool, config_dir, false, cache_dir: cache_dir)
+    end
   end
 elsif yaml_source
   yaml_source = yaml_source.gsub(/\$\((\w+)\)|\$\{(\w+)\}/) {ENV[$1||$2]}


### PR DESCRIPTION
These tools bundled with libyaml tarball are too old for cross-compiling
for wasm targets