### PR TITLE
Propagate `CC` to libyaml

### DIFF
--- a/ext/psych/extconf.rb
+++ b/ext/psych/extconf.rb
@@ -45,6 +45,7 @@ if yaml_source
     yaml_configure,
     "--enable-#{shared ? 'shared' : 'static'}",
     "--host=#{RbConfig::CONFIG['host'].sub(/-unknown-/, '-')}",
+    "CC=#{RbConfig::CONFIG['CC']}",
     *(["CFLAGS=-w"] if RbConfig::CONFIG["GCC"] == "yes"),
   ]
   puts(args.quote.join(' '))


### PR DESCRIPTION
It is needed for cross-compiling to set properly.
Just `--target`/`--host`/`--build` seems insufficient on some platforms.