### PR TITLE
Improve libyaml source downloading error messages

### DIFF
--- a/ext/psych/extconf.rb
+++ b/ext/psych/extconf.rb
@@ -19,10 +19,16 @@ if yaml_source == true
   # search the latest libyaml source under $srcdir
   yaml_source = Dir.glob("#{$srcdir}/yaml{,-*}/").max_by {|n| File.basename(n).scan(/\d+/).map(&:to_i)}
   unless yaml_source
-    require_relative '../../tool/extlibs.rb'
-    extlibs = ExtLibs.new(cache_dir: File.expand_path("../../tmp/download_cache", $srcdir))
-    unless extlibs.process_under($srcdir)
-      raise "failed to download libyaml source"
+    download_failure = "failed to download libyaml source"
+    begin
+      require_relative '../../tool/extlibs.rb'
+      extlibs = ExtLibs.new(cache_dir: File.expand_path("../../tmp/download_cache", $srcdir))
+      unless extlibs.process_under($srcdir)
+        raise download_failure
+      end
+    rescue
+      # Implicitly captures Exception#cause. Newer rubies show it in the backtrace.
+      raise download_failure
     end
     yaml_source, = Dir.glob("#{$srcdir}/yaml-*/")
     raise "libyaml not found" unless yaml_source


### PR DESCRIPTION
People trying to build CRuby by following the instructions in its
[README] have been running into [errors] due to missing `libyaml`
on their system. Let's try to present a better error message when
it happens.

[README]: https://github.com/ruby/ruby/tree/fb5aa31e2d20ea8e1425432672f4de4c8ca2c26b#how-to-compile-and-install
[errors]: https://github.com/ruby/psych/issues/552