### PR TITLE
Raise specific error when aliases are not enabled

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -307,7 +307,7 @@ module Psych
   # A Psych::DisallowedClass exception will be raised if the yaml contains a
   # class that isn't in the +permitted_classes+ list.
   #
-  # A Psych::BadAlias exception will be raised if the yaml contains aliases
+  # A Psych::AliasesNotEnabled exception will be raised if the yaml contains aliases
   # but the +aliases+ keyword argument is set to false.
   #
   # +filename+ will be used in the exception message if any exception is raised

--- a/lib/psych/exception.rb
+++ b/lib/psych/exception.rb
@@ -6,6 +6,13 @@ module Psych
   class BadAlias < Exception
   end
 
+  # Subclasses `BadAlias` for backwards compatibility
+  class AliasesNotEnabled < BadAlias
+    def initialize
+      super "Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`."
+    end
+  end
+
   class DisallowedClass < Exception
     def initialize action, klass_name
       super "Tried to #{action} unspecified class: #{klass_name}"

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -427,7 +427,7 @@ module Psych
 
     class NoAliasRuby < ToRuby
       def visit_Psych_Nodes_Alias o
-        raise BadAlias, "Unknown alias: #{o.anchor}"
+        raise AliasesNotEnabled
       end
     end
   end

--- a/test/psych/helper.rb
+++ b/test/psych/helper.rb
@@ -51,7 +51,7 @@ module Psych
           :UseVersion => true, :UseHeader => true, :SortKeys => true
         )
       ))
-    rescue Psych::DisallowedClass, Psych::BadAlias
+    rescue Psych::DisallowedClass, Psych::BadAlias, Psych::AliasesNotEnabled
       assert_to_yaml obj, yaml, :unsafe_load
     end
 
@@ -61,7 +61,7 @@ module Psych
     def assert_parse_only( obj, yaml )
       begin
         assert_equal obj, Psych::load( yaml )
-      rescue Psych::DisallowedClass, Psych::BadAlias
+      rescue Psych::DisallowedClass, Psych::BadAlias, Psych::AliasesNotEnabled
         assert_equal obj, Psych::unsafe_load( yaml )
       end
       assert_equal obj, Psych::parse( yaml ).transform
@@ -79,7 +79,7 @@ module Psych
           assert_equal(obj, Psych.load(v.tree.yaml))
           assert_equal(obj, Psych::load(Psych.dump(obj)))
           assert_equal(obj, Psych::load(obj.to_yaml))
-        rescue Psych::DisallowedClass, Psych::BadAlias
+        rescue Psych::DisallowedClass, Psych::BadAlias, Psych::AliasesNotEnabled
           assert_equal(obj, Psych.unsafe_load(v.tree.yaml))
           assert_equal(obj, Psych::unsafe_load(Psych.dump(obj)))
           assert_equal(obj, Psych::unsafe_load(obj.to_yaml))

--- a/test/psych/test_array.rb
+++ b/test/psych/test_array.rb
@@ -68,7 +68,7 @@ module Psych
     def test_recursive_array_uses_alias
       @list << @list
 
-      assert_raise(BadAlias) do
+      assert_raise(AliasesNotEnabled) do
         Psych.load(Psych.dump(@list), aliases: false)
       end
     end

--- a/test/psych/test_array.rb
+++ b/test/psych/test_array.rb
@@ -57,6 +57,19 @@ module Psych
       assert_cycle(@list)
     end
 
+    def test_recursive_array_uses_alias
+      @list << @list
+
+      expected = <<~eoyaml
+        --- &1
+        - :a: b
+        - foo
+        - *1
+      eoyaml
+
+      assert_equal expected, Psych.dump(@list)
+    end
+
     def test_cycle
       assert_cycle(@list)
     end

--- a/test/psych/test_array.rb
+++ b/test/psych/test_array.rb
@@ -57,17 +57,20 @@ module Psych
       assert_cycle(@list)
     end
 
+    def test_recursive_array
+      @list << @list
+
+      loaded = Psych.load(Psych.dump(@list), aliases: true)
+
+      assert_same loaded, loaded.last
+    end
+
     def test_recursive_array_uses_alias
       @list << @list
 
-      expected = <<~eoyaml
-        --- &1
-        - :a: b
-        - foo
-        - *1
-      eoyaml
-
-      assert_equal expected, Psych.dump(@list)
+      assert_raise(BadAlias) do
+        Psych.load(Psych.dump(@list), aliases: false)
+      end
     end
 
     def test_cycle

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -112,6 +112,18 @@ eoyml
       assert_equal({"foo"=>{"hello"=>"world"}, "bar"=>{"hello"=>"world"}}, hash)
     end
 
+    def test_recursive_hash_uses_alias
+      h = { }
+      h["recursive_reference"] = h
+
+      expected = <<~eoyaml
+        --- &1
+        recursive_reference: *1
+      eoyaml
+
+      assert_equal(expected, Psych.dump(h))
+    end
+
     def test_key_deduplication
       unless String.method_defined?(:-@) && (-("a" * 20)).equal?((-("a" * 20)))
         pend "This Ruby implementation doesn't support string deduplication"

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -125,7 +125,7 @@ eoyml
       h = { }
       h["recursive_reference"] = h
 
-      assert_raise(BadAlias) do
+      assert_raise(AliasesNotEnabled) do
         Psych.load(Psych.dump(h), aliases: false)
       end
     end

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -112,16 +112,22 @@ eoyml
       assert_equal({"foo"=>{"hello"=>"world"}, "bar"=>{"hello"=>"world"}}, hash)
     end
 
+    def test_recursive_hash
+      h = { }
+      h["recursive_reference"] = h
+
+      loaded = Psych.load(Psych.dump(h), aliases: true)
+
+      assert_same loaded, loaded.fetch("recursive_reference")
+    end
+
     def test_recursive_hash_uses_alias
       h = { }
       h["recursive_reference"] = h
 
-      expected = <<~eoyaml
-        --- &1
-        recursive_reference: *1
-      eoyaml
-
-      assert_equal(expected, Psych.dump(h))
+      assert_raise(BadAlias) do
+        Psych.load(Psych.dump(h), aliases: false)
+      end
     end
 
     def test_key_deduplication

--- a/test/psych/test_merge_keys.rb
+++ b/test/psych/test_merge_keys.rb
@@ -117,7 +117,7 @@ development:
 bar:
   << : *foo
       eoyml
-      exp = assert_raise(Psych::BadAlias) { Psych.load yaml }
+      exp = assert_raise(Psych::BadAlias) { Psych.load(yaml, aliases: true) }
       assert_match 'foo', exp.message
     end
 

--- a/test/psych/test_object.rb
+++ b/test/psych/test_object.rb
@@ -41,5 +41,17 @@ module Psych
       assert_instance_of(Foo, loaded)
       assert_equal loaded, loaded.parent
     end
+
+    def test_cyclic_reference_uses_alias
+      foo = Foo.new(nil)
+      foo.parent = foo
+
+      expected = <<~eoyaml
+        --- &1 !ruby/object:Psych::Foo
+        parent: *1
+      eoyaml
+
+      assert_equal expected, Psych.dump(foo)
+    end
   end
 end

--- a/test/psych/test_object.rb
+++ b/test/psych/test_object.rb
@@ -46,7 +46,7 @@ module Psych
       foo = Foo.new(nil)
       foo.parent = foo
 
-      assert_raise(BadAlias) do
+      assert_raise(AliasesNotEnabled) do
         Psych.load(Psych.dump(foo), permitted_classes: [Foo], aliases: false)
       end
     end

--- a/test/psych/test_object.rb
+++ b/test/psych/test_object.rb
@@ -36,22 +36,19 @@ module Psych
     def test_cyclic_references
       foo = Foo.new(nil)
       foo.parent = foo
-      loaded = Psych.unsafe_load Psych.dump foo
+      loaded = Psych.load(Psych.dump(foo), permitted_classes: [Foo], aliases: true)
 
       assert_instance_of(Foo, loaded)
-      assert_equal loaded, loaded.parent
+      assert_same loaded, loaded.parent
     end
 
     def test_cyclic_reference_uses_alias
       foo = Foo.new(nil)
       foo.parent = foo
 
-      expected = <<~eoyaml
-        --- &1 !ruby/object:Psych::Foo
-        parent: *1
-      eoyaml
-
-      assert_equal expected, Psych.dump(foo)
+      assert_raise(BadAlias) do
+        Psych.load(Psych.dump(foo), permitted_classes: [Foo], aliases: false)
+      end
     end
   end
 end

--- a/test/psych/test_safe_load.rb
+++ b/test/psych/test_safe_load.rb
@@ -19,18 +19,31 @@ module Psych
       end
     end
 
-    def test_no_recursion
-      x = []
-      x << x
+    def test_raises_when_alias_found_if_alias_parsing_not_enabled
+      yaml_with_aliases = <<~YAML
+        ---
+        a: &ABC
+          k1: v1
+          k2: v2
+        b: *ABC
+      YAML
+
       assert_raise(Psych::BadAlias) do
-        Psych.safe_load Psych.dump(x)
+        Psych.safe_load(yaml_with_aliases)
       end
     end
 
-    def test_explicit_recursion
-      x = []
-      x << x
-      assert_equal(x, Psych.safe_load(Psych.dump(x), permitted_classes: [], permitted_symbols: [], aliases: true))
+    def test_aliases_are_parsed_when_alias_parsing_is_enabled
+      yaml_with_aliases = <<~YAML
+        ---
+        a: &ABC
+          k1: v1
+          k2: v2
+        b: *ABC
+      YAML
+
+      result = Psych.safe_load(yaml_with_aliases, aliases: true)
+      assert_same result.fetch("a"), result.fetch("b")
     end
 
     def test_permitted_symbol

--- a/test/psych/test_safe_load.rb
+++ b/test/psych/test_safe_load.rb
@@ -28,7 +28,7 @@ module Psych
         b: *ABC
       YAML
 
-      assert_raise(Psych::BadAlias) do
+      assert_raise(Psych::AliasesNotEnabled) do
         Psych.safe_load(yaml_with_aliases)
       end
     end


### PR DESCRIPTION
Fixes #565

Introduces a new error, `Psych::AliasesNotEnabled`. For backwards compatibility, it's a subclass of `Psych::BadAlias`, so that old `rescue` blocks keeping working as intended.
