### PR TITLE
Clarify tests about parsing aliases

### DIFF
--- a/test/psych/test_array.rb
+++ b/test/psych/test_array.rb
@@ -57,6 +57,19 @@ module Psych
       assert_cycle(@list)
     end
 
+    def test_recursive_array_uses_alias
+      @list << @list
+
+      expected = <<~eoyaml
+        --- &1
+        - :a: b
+        - foo
+        - *1
+      eoyaml
+
+      assert_equal expected, Psych.dump(@list)
+    end
+
     def test_cycle
       assert_cycle(@list)
     end

--- a/test/psych/test_array.rb
+++ b/test/psych/test_array.rb
@@ -57,17 +57,20 @@ module Psych
       assert_cycle(@list)
     end
 
+    def test_recursive_array
+      @list << @list
+
+      loaded = Psych.load(Psych.dump(@list), aliases: true)
+
+      assert_same loaded, loaded.last
+    end
+
     def test_recursive_array_uses_alias
       @list << @list
 
-      expected = <<~eoyaml
-        --- &1
-        - :a: b
-        - foo
-        - *1
-      eoyaml
-
-      assert_equal expected, Psych.dump(@list)
+      assert_raise(BadAlias) do
+        Psych.load(Psych.dump(@list), aliases: false)
+      end
     end
 
     def test_cycle

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -112,6 +112,18 @@ eoyml
       assert_equal({"foo"=>{"hello"=>"world"}, "bar"=>{"hello"=>"world"}}, hash)
     end
 
+    def test_recursive_hash_uses_alias
+      h = { }
+      h["recursive_reference"] = h
+
+      expected = <<~eoyaml
+        --- &1
+        recursive_reference: *1
+      eoyaml
+
+      assert_equal(expected, Psych.dump(h))
+    end
+
     def test_key_deduplication
       unless String.method_defined?(:-@) && (-("a" * 20)).equal?((-("a" * 20)))
         pend "This Ruby implementation doesn't support string deduplication"

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -112,16 +112,22 @@ eoyml
       assert_equal({"foo"=>{"hello"=>"world"}, "bar"=>{"hello"=>"world"}}, hash)
     end
 
+    def test_recursive_hash
+      h = { }
+      h["recursive_reference"] = h
+
+      loaded = Psych.load(Psych.dump(h), aliases: true)
+
+      assert_same loaded, loaded.fetch("recursive_reference")
+    end
+
     def test_recursive_hash_uses_alias
       h = { }
       h["recursive_reference"] = h
 
-      expected = <<~eoyaml
-        --- &1
-        recursive_reference: *1
-      eoyaml
-
-      assert_equal(expected, Psych.dump(h))
+      assert_raise(BadAlias) do
+        Psych.load(Psych.dump(h), aliases: false)
+      end
     end
 
     def test_key_deduplication

--- a/test/psych/test_object.rb
+++ b/test/psych/test_object.rb
@@ -41,5 +41,17 @@ module Psych
       assert_instance_of(Foo, loaded)
       assert_equal loaded, loaded.parent
     end
+
+    def test_cyclic_reference_uses_alias
+      foo = Foo.new(nil)
+      foo.parent = foo
+
+      expected = <<~eoyaml
+        --- &1 !ruby/object:Psych::Foo
+        parent: *1
+      eoyaml
+
+      assert_equal expected, Psych.dump(foo)
+    end
   end
 end

--- a/test/psych/test_object.rb
+++ b/test/psych/test_object.rb
@@ -36,22 +36,19 @@ module Psych
     def test_cyclic_references
       foo = Foo.new(nil)
       foo.parent = foo
-      loaded = Psych.unsafe_load Psych.dump foo
+      loaded = Psych.load(Psych.dump(foo), permitted_classes: [Foo], aliases: true)
 
       assert_instance_of(Foo, loaded)
-      assert_equal loaded, loaded.parent
+      assert_same loaded, loaded.parent
     end
 
     def test_cyclic_reference_uses_alias
       foo = Foo.new(nil)
       foo.parent = foo
 
-      expected = <<~eoyaml
-        --- &1 !ruby/object:Psych::Foo
-        parent: *1
-      eoyaml
-
-      assert_equal expected, Psych.dump(foo)
+      assert_raise(BadAlias) do
+        Psych.load(Psych.dump(foo), permitted_classes: [Foo], aliases: false)
+      end
     end
   end
 end

--- a/test/psych/test_safe_load.rb
+++ b/test/psych/test_safe_load.rb
@@ -19,18 +19,31 @@ module Psych
       end
     end
 
-    def test_no_recursion
-      x = []
-      x << x
+    def test_raises_when_alias_found_if_alias_parsing_not_enabled
+      yaml_with_aliases = <<~YAML
+        ---
+        a: &ABC
+          k1: v1
+          k2: v2
+        b: *ABC
+      YAML
+
       assert_raise(Psych::BadAlias) do
-        Psych.safe_load Psych.dump(x)
+        Psych.safe_load(yaml_with_aliases)
       end
     end
 
-    def test_explicit_recursion
-      x = []
-      x << x
-      assert_equal(x, Psych.safe_load(Psych.dump(x), permitted_classes: [], permitted_symbols: [], aliases: true))
+    def test_aliases_are_parsed_when_alias_parsing_is_enabled
+      yaml_with_aliases = <<~YAML
+        ---
+        a: &ABC
+          k1: v1
+          k2: v2
+        b: *ABC
+      YAML
+
+      result = Psych.safe_load(yaml_with_aliases, aliases: true)
+      assert_same result.fetch("a"), result.fetch("b")
     end
 
     def test_permitted_symbol


### PR DESCRIPTION
Split from #567.

These tests don't really have actually anything special to do with recursion. The behaviour being asserted is about how any kind of alias works.