### PR TITLE
Bump snakeyaml from 1.28 to 1.31 to resolve CVE-2022-25857

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -5,6 +5,6 @@ module Psych
   VERSION = '5.0.0.dev'
 
   if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '1.28'.freeze
+    DEFAULT_SNAKEYAML_VERSION = '1.31'.freeze
   end
 end


### PR DESCRIPTION
Resolves CVE-2022-25857 within snakeyaml, among other fixes.

Suggest cherrypick to 4-0-stable and any other maintained versions.

Additional context
- https://nvd.nist.gov/vuln/detail/CVE-2022-25857
- The fix for the issue https://github.com/snakeyaml/snakeyaml/commit/fc300780da21f4bb92c148bc90257201220cf174
- [Snakeyaml changelog](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
- https://github.com/jruby/jruby/issues/7342
