### PR TITLE
3.3.x: Bump snakeyaml from 1.29 to 1.31

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -5,6 +5,6 @@ module Psych
   VERSION = '3.3.2'
 
   if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '1.29'.freeze
+    DEFAULT_SNAKEYAML_VERSION = '1.31'.freeze
   end
 end


### PR DESCRIPTION
Cherry-pick of https://github.com/ruby/psych/pull/574 Resolves CVE-2022-25857, among other fixes.

Looks like there is/was an unreleased bump to SnakeYaml 1.29 in ff29c59bebf942293c96fe5370294fc67757e013 - not sure if any concerns here.

Additional context
- https://nvd.nist.gov/vuln/detail/CVE-2022-25857
- The fix for the issue https://github.com/snakeyaml/snakeyaml/commit/fc300780da21f4bb92c148bc90257201220cf174
- [Snakeyaml changelog](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
- https://github.com/jruby/jruby/issues/7342