### PR TITLE
Bump snakeyaml from 1.31 to 1.33 to resolve CVE-2022-38752 on JRuby

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -5,6 +5,6 @@ module Psych
   VERSION = '5.0.0.dev'
 
   if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '1.31'.freeze
+    DEFAULT_SNAKEYAML_VERSION = '1.33'.freeze
   end
 end


### PR DESCRIPTION
Resolves CVE-2022-38752 and makes another couple of defensive changes around code point limits.

Additional context
- Follow up to #574 
- Most issue discussion [here](https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081). Seems a relatively minor issue, but will help folks reduce noise from scanners.
- [Snakeyaml changelog](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)