### PR TITLE
backport (3.x): Bump snakeyaml from 1.31 to 1.33 to resolve CVE-2022-38752 on JRuby

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -2,7 +2,7 @@
 
 module Psych
   # The version of Psych you are using
-  VERSION = '3.3.3'
+  VERSION = '3.3.4'
 
   if RUBY_ENGINE == 'jruby'
     DEFAULT_SNAKEYAML_VERSION = '1.33'.freeze

--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -5,6 +5,6 @@ module Psych
   VERSION = '3.3.3'
 
   if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '1.31'.freeze
+    DEFAULT_SNAKEYAML_VERSION = '1.33'.freeze
   end
 end


### PR DESCRIPTION
Resolves CVE-2022-38752 and makes another couple of defensive changes around code point limits.

Backport of  #585.

Additional context
- Follow up to #574 
- Most issue discussion [here](https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081). Seems a relatively minor issue, but will help folks reduce noise from scanners.
- [Snakeyaml changelog](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)