### PR TITLE
Relax restricted classes

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -363,9 +363,10 @@ module Psych
   #   Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
   # Raises a TypeError when `yaml` parameter is NilClass.  This method is
-  # similar to `safe_load` except that `Symbol` objects are allowed by default.
+  # similar to `safe_load` except that `Symbol`, Date, DateTime and Time objects
+  # are allowed by default.
   #
-  def self.load yaml, permitted_classes: [Symbol], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
+  def self.load yaml, permitted_classes: [Symbol, Date, DateTime, Time], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
     safe_load yaml, permitted_classes: permitted_classes,
                     permitted_symbols: permitted_symbols,
                     aliases: aliases,

--- a/lib/psych/class_loader.rb
+++ b/lib/psych/class_loader.rb
@@ -17,6 +17,7 @@ module Psych
     REGEXP      = 'Regexp'
     STRUCT      = 'Struct'
     SYMBOL      = 'Symbol'
+    TIME        = 'Time'
 
     def initialize
       @cache = CACHE.dup

--- a/test/psych/test_object_references.rb
+++ b/test/psych/test_object_references.rb
@@ -36,6 +36,8 @@ module Psych
       assert_match(/\*-?\d+/, yml)
       begin
         data = Psych.load yml
+      rescue Psych::AliasesNotEnabled
+        data = Psych.load yml, aliases: true
       rescue Psych::DisallowedClass
         data = Psych.unsafe_load yml
       end


### PR DESCRIPTION
Pych 4 change the default behavior of `load` to `safe_load` and add `Symbol` into `permitted_classes`.

I propose also adding `Date`, `DateTime` and `Time` into `permitted_classes`. 

Related with https://github.com/ruby/psych/issues/604

But I'm not security experts, I'm not sure this change is safe way for the Ruby language.