### PR TITLE
Fix wrong package name of MSYS2/MINGW dependency

### DIFF
--- a/psych.gemspec
+++ b/psych.gemspec
@@ -63,6 +63,6 @@ DESCRIPTION
     s.add_dependency 'stringio'
   end
 
-  s.metadata['msys2_mingw_dependencies'] = 'libyaml libyaml-devel'
+  s.metadata['msys2_mingw_dependencies'] = 'libyaml'
 
 end


### PR DESCRIPTION
There is no package called "libyaml-devel". "libyaml" is enough. It was introduced in #601.

Using a wrong package name leads to not installing any package, so that the output of `gem install` is like so:

```sh
c:\Users\kanis\psych>gem inst pkg\psych-5.0.1.gem
Using rubygems directory: C:/Users/kanis/.gem/ruby/3.2.0
Installing required msys2 packages: mingw-w64-ucrt-x86_64-libyaml mingw-w64-ucrt-x86_64-libyaml-devel
Fehler: Ziel nicht gefunden: mingw-w64-ucrt-x86_64-libyaml-devel
pacman failed with the following output:
Building native extensions. This could take a while...
ERROR:  Error installing pkg\psych-5.0.1.gem:
        ERROR: Failed to build gem native extension.

    current directory: C:/Users/kanis/.gem/ruby/3.2.0/gems/psych-5.0.1/ext/psych
C:/Ruby32-x64/bin/ruby.exe -I C:/Ruby32-x64/lib/ruby/3.2.0 extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=C:/Ruby32-x64/bin/$(RUBY_BASE_NAME)
        --with-libyaml-source-dir
        --without-libyaml-source-dir
        --with-yaml-0.1-dir
        --without-yaml-0.1-dir
        --with-yaml-0.1-include
        --without-yaml-0.1-include=${yaml-0.1-dir}/include
        --with-yaml-0.1-lib
        --without-yaml-0.1-lib=${yaml-0.1-dir}/lib
        --with-yaml-0.1-config
        --without-yaml-0.1-config
        --with-pkg-config
        --without-pkg-config
        --with-libyaml-dir
        --without-libyaml-dir
        --with-libyaml-include
        --without-libyaml-include=${libyaml-dir}/include
        --with-libyaml-lib
        --without-libyaml-lib=${libyaml-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  C:/Users/kanis/.gem/ruby/3.2.0/extensions/x64-mingw-ucrt/3.2.0/psych-5.0.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in C:/Users/kanis/.gem/ruby/3.2.0/gems/psych-5.0.1 for inspection.
Results logged to C:/Users/kanis/.gem/ruby/3.2.0/extensions/x64-mingw-ucrt/3.2.0/psych-5.0.1/gem_make.out
```

With the fix in this PR `gem install` works like expected:
```sh
c:\Users\kanis\psych>gem inst pkg\psych-5.0.1.gem
Using rubygems directory: C:/Users/kanis/.gem/ruby/3.2.0
Installing required msys2 packages: mingw-w64-ucrt-x86_64-libyaml
Building native extensions. This could take a while...
Successfully installed psych-5.0.1
Parsing documentation for psych-5.0.1
Done installing documentation for psych after 0 seconds
1 gem installed
```
