### PR TITLE
Get rid of anonymous eval calls

### DIFF
--- a/lib/psych/class_loader.rb
+++ b/lib/psych/class_loader.rb
@@ -35,7 +35,7 @@ module Psych
 
     constants.each do |const|
       konst = const_get const
-      class_eval <<~RUBY
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def #{const.to_s.downcase}
           load #{konst.inspect}
         end

--- a/lib/psych/tree_builder.rb
+++ b/lib/psych/tree_builder.rb
@@ -41,7 +41,7 @@ module Psych
       Sequence
       Mapping
     }.each do |node|
-      class_eval %{
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def start_#{node.downcase}(anchor, tag, implicit, style)
           n = Nodes::#{node}.new(anchor, tag, implicit, style)
           set_start_location(n)
@@ -54,7 +54,7 @@ module Psych
           set_end_location(n)
           n
         end
-      }
+        RUBY
     end
 
     ###

--- a/test/psych/test_encoding.rb
+++ b/test/psych/test_encoding.rb
@@ -13,13 +13,13 @@ module Psych
 
       (Handler.instance_methods(true) -
        Object.instance_methods).each do |m|
-        class_eval %{
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{m} *args
             @strings += args.flatten.find_all { |a|
               String === a
             }
           end
-        }
+        RUBY
       end
     end
 

--- a/test/psych/test_parser.rb
+++ b/test/psych/test_parser.rb
@@ -16,13 +16,13 @@ module Psych
 
       (Handler.instance_methods(true) -
        Object.instance_methods).each do |m|
-        class_eval %{
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{m} *args
             super
             @marks << @parser.mark if @parser
             @calls << [:#{m}, args]
           end
-        }
+        RUBY
       end
     end
 


### PR DESCRIPTION
Things declared in anonymous eval are always annoying to locate.