### PR TITLE
Move JRuby extension to SnakeYAML Engine

### DIFF
--- a/Mavenfile
+++ b/Mavenfile
@@ -1,6 +1,6 @@
 #-*- mode: ruby -*-
 
-jar 'org.yaml:snakeyaml:${snakeyaml.version}'
+jar 'org.snakeyaml:snakeyaml-engine:${snakeyaml.version}'
 
 plugin :dependency, '2.8', :outputFile => 'pkg/classpath'
 

--- a/ext/java/org/jruby/ext/psych/PsychEmitter.java
+++ b/ext/java/org/jruby/ext/psych/PsychEmitter.java
@@ -140,13 +140,18 @@ public class PsychEmitter extends RubyObject {
         TypeConverter.checkType(context, _version, arrayClass);
 
         RubyArray versionAry = _version.convertToArray();
+        Optional<SpecVersion> specVersion;
         if (versionAry.size() == 2) {
             int versionInt0 = versionAry.eltInternal(0).convertToInteger().getIntValue();
             int versionInt1 = versionAry.eltInternal(1).convertToInteger().getIntValue();
 
-            if (versionInt0 != 1 || versionInt1 != 2) {
-//                throw runtime.newArgumentError("invalid YAML version: " + versionAry);
+            if (versionInt0 != 1) {
+                throw runtime.newArgumentError("invalid YAML version: " + versionAry);
             }
+
+            specVersion = Optional.of(new SpecVersion(versionInt0, versionInt1));
+        } else {
+            specVersion = Optional.empty();
         }
 
         Map<String, String> tagsMap = new HashMap<>();
@@ -171,7 +176,7 @@ public class PsychEmitter extends RubyObject {
             }
         }
 
-        DocumentStartEvent event = new DocumentStartEvent(!implicitBool, Optional.empty(), tagsMap, NULL_MARK, NULL_MARK);
+        DocumentStartEvent event = new DocumentStartEvent(!implicitBool, specVersion, tagsMap, NULL_MARK, NULL_MARK);
         emit(context, event);
         return this;
     }

--- a/ext/java/org/jruby/ext/psych/PsychEmitter.java
+++ b/ext/java/org/jruby/ext/psych/PsychEmitter.java
@@ -118,17 +118,14 @@ public class PsychEmitter extends RubyObject {
 
         initEmitter(context, encoding);
 
-        StreamStartEvent event = new StreamStartEvent(NULL_MARK, NULL_MARK);
-
-        emit(context, event);
+        emit(context, NULL_STREAM_START_EVENT);
 
         return this;
     }
 
     @JRubyMethod
     public IRubyObject end_stream(ThreadContext context) {
-        StreamEndEvent event = new StreamEndEvent(NULL_MARK, NULL_MARK);
-        emit(context, event);
+        emit(context, NULL_STREAM_START_EVENT);
         return this;
     }
 
@@ -368,16 +365,16 @@ public class PsychEmitter extends RubyObject {
         return dumpSettingsBuilder.build();
     }
 
-    private String exportToUTF8(ThreadContext context, IRubyObject tag, RubyClass stringClass) {
-        if (tag.isNil()) {
+    private String exportToUTF8(ThreadContext context, IRubyObject maybeString, RubyClass stringClass) {
+        if (maybeString.isNil()) {
             return null;
         }
 
-        RubyString tagStr;
+        RubyString string;
 
-        TypeConverter.checkType(context, tag, stringClass);
-        tagStr = (RubyString) tag;
-        ByteList bytes = tagStr.getByteList();
+        TypeConverter.checkType(context, maybeString, stringClass);
+        string = (RubyString) maybeString;
+        ByteList bytes = string.getByteList();
 
         return RubyEncoding.decodeUTF8(bytes.unsafeBytes(), bytes.begin(), bytes.realSize());
     }
@@ -388,6 +385,7 @@ public class PsychEmitter extends RubyObject {
     IRubyObject io;
 
     private static final Optional<Mark> NULL_MARK = Optional.empty();
+    private static final StreamStartEvent NULL_STREAM_START_EVENT = new StreamStartEvent(NULL_MARK, NULL_MARK);
 
     // Map style constants from Psych values (ANY = 0 ... FOLDED = 5)
     // to SnakeYaml values; see psych/nodes/scalar.rb.

--- a/ext/java/org/jruby/ext/psych/PsychEmitter.java
+++ b/ext/java/org/jruby/ext/psych/PsychEmitter.java
@@ -149,7 +149,6 @@ public class PsychEmitter extends RubyObject {
             }
         }
 
-        SpecVersion version = new SpecVersion(1, 2);
         Map<String, String> tagsMap = new HashMap<>();
 
         if (!tags.isNil()) {
@@ -172,7 +171,7 @@ public class PsychEmitter extends RubyObject {
             }
         }
 
-        DocumentStartEvent event = new DocumentStartEvent(!implicitBool, Optional.ofNullable(version), tagsMap, NULL_MARK, NULL_MARK);
+        DocumentStartEvent event = new DocumentStartEvent(!implicitBool, Optional.empty(), tagsMap, NULL_MARK, NULL_MARK);
         emit(context, event);
         return this;
     }

--- a/ext/java/org/jruby/ext/psych/PsychEmitter.java
+++ b/ext/java/org/jruby/ext/psych/PsychEmitter.java
@@ -33,12 +33,14 @@ import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
+import org.jruby.RubyEncoding;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 import org.jruby.util.IOOutputStream;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.io.EncodingUtils;
@@ -375,8 +377,9 @@ public class PsychEmitter extends RubyObject {
 
         TypeConverter.checkType(context, tag, stringClass);
         tagStr = (RubyString) tag;
+        ByteList bytes = tagStr.getByteList();
 
-        return EncodingUtils.strConvEnc(context, tagStr, tagStr.getEncoding(), UTF8Encoding.INSTANCE).asJavaString();
+        return RubyEncoding.decodeUTF8(bytes.unsafeBytes(), bytes.begin(), bytes.realSize());
     }
 
     Emitter emitter;

--- a/ext/java/org/jruby/ext/psych/PsychEmitter.java
+++ b/ext/java/org/jruby/ext/psych/PsychEmitter.java
@@ -27,48 +27,52 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ext.psych;
 
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.IOOutputStream;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.io.EncodingUtils;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.emitter.Emitter;
-import org.yaml.snakeyaml.emitter.EmitterException;
-import org.yaml.snakeyaml.error.Mark;
-import org.yaml.snakeyaml.events.AliasEvent;
-import org.yaml.snakeyaml.events.DocumentEndEvent;
-import org.yaml.snakeyaml.events.DocumentStartEvent;
-import org.yaml.snakeyaml.events.Event;
-import org.yaml.snakeyaml.events.ImplicitTuple;
-import org.yaml.snakeyaml.events.MappingEndEvent;
-import org.yaml.snakeyaml.events.MappingStartEvent;
-import org.yaml.snakeyaml.events.ScalarEvent;
-import org.yaml.snakeyaml.events.SequenceEndEvent;
-import org.yaml.snakeyaml.events.SequenceStartEvent;
-import org.yaml.snakeyaml.events.StreamEndEvent;
-import org.yaml.snakeyaml.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.api.DumpSettingsBuilder;
+import org.snakeyaml.engine.v2.api.StreamDataWriter;
+import org.snakeyaml.engine.v2.api.YamlOutputStreamWriter;
+import org.snakeyaml.engine.v2.common.Anchor;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.snakeyaml.engine.v2.common.ScalarStyle;
+import org.snakeyaml.engine.v2.common.SpecVersion;
+import org.snakeyaml.engine.v2.emitter.Emitter;
+import org.snakeyaml.engine.v2.events.AliasEvent;
+import org.snakeyaml.engine.v2.events.DocumentEndEvent;
+import org.snakeyaml.engine.v2.events.DocumentStartEvent;
+import org.snakeyaml.engine.v2.events.Event;
+import org.snakeyaml.engine.v2.events.ImplicitTuple;
+import org.snakeyaml.engine.v2.events.MappingEndEvent;
+import org.snakeyaml.engine.v2.events.MappingStartEvent;
+import org.snakeyaml.engine.v2.events.ScalarEvent;
+import org.snakeyaml.engine.v2.events.SequenceEndEvent;
+import org.snakeyaml.engine.v2.events.SequenceStartEvent;
+import org.snakeyaml.engine.v2.events.StreamEndEvent;
+import org.snakeyaml.engine.v2.events.StreamStartEvent;
+import org.snakeyaml.engine.v2.exceptions.EmitterException;
+import org.snakeyaml.engine.v2.exceptions.Mark;
 
-import static org.jruby.runtime.Visibility.*;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.jruby.runtime.Visibility.PRIVATE;
 
 public class PsychEmitter extends RubyObject {
     public static void initPsychEmitter(Ruby runtime, RubyModule psych) {
@@ -84,8 +88,7 @@ public class PsychEmitter extends RubyObject {
 
     @JRubyMethod(visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject io) {
-        options = new DumperOptions();
-        options.setIndent(2);
+        dumpSettingsBuilder.setIndent(2);
 
         this.io = io;
 
@@ -98,10 +101,8 @@ public class PsychEmitter extends RubyObject {
         IRubyObject canonical = rbOptions.callMethod(context, "canonical");
         IRubyObject level     = rbOptions.callMethod(context, "indentation");
 
-        options = new DumperOptions();
-
-        options.setCanonical(canonical.isTrue());
-        options.setIndent((int)level.convertToInteger().getLongValue());
+        dumpSettingsBuilder.setCanonical(canonical.isTrue());
+        dumpSettingsBuilder.setIndent((int)level.convertToInteger().getLongValue());
         line_width_set(context, width);
 
         this.io = io;
@@ -133,9 +134,7 @@ public class PsychEmitter extends RubyObject {
     public IRubyObject start_document(ThreadContext context, IRubyObject _version, IRubyObject tags, IRubyObject implicit) {
         Ruby runtime = context.runtime;
 
-        DumperOptions.Version version = null;
         boolean implicitBool = implicit.isTrue();
-        Map<String, String> tagsMap = null;
 
         RubyClass arrayClass = runtime.getArray();
         TypeConverter.checkType(context, _version, arrayClass);
@@ -145,17 +144,13 @@ public class PsychEmitter extends RubyObject {
             int versionInt0 = versionAry.eltInternal(0).convertToInteger().getIntValue();
             int versionInt1 = versionAry.eltInternal(1).convertToInteger().getIntValue();
 
-            if (versionInt0 == 1) {
-                if (versionInt1 == 0) {
-                    version = DumperOptions.Version.V1_0;
-                } else if (versionInt1 == 1) {
-                    version = DumperOptions.Version.V1_1;
-                }
-            }
-            if (version == null) {
-                throw runtime.newArgumentError("invalid YAML version: " + versionAry);
+            if (versionInt0 != 1 || versionInt1 != 2) {
+//                throw runtime.newArgumentError("invalid YAML version: " + versionAry);
             }
         }
+
+        SpecVersion version = new SpecVersion(1, 2);
+        Map<String, String> tagsMap = new HashMap<>();
 
         if (!tags.isNil()) {
             TypeConverter.checkType(context, tags, arrayClass);
@@ -177,14 +172,14 @@ public class PsychEmitter extends RubyObject {
             }
         }
 
-        DocumentStartEvent event = new DocumentStartEvent(NULL_MARK, NULL_MARK, !implicitBool, version, tagsMap);
+        DocumentStartEvent event = new DocumentStartEvent(!implicitBool, Optional.ofNullable(version), tagsMap, NULL_MARK, NULL_MARK);
         emit(context, event);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject end_document(ThreadContext context, IRubyObject implicit) {
-        DocumentEndEvent event = new DocumentEndEvent(NULL_MARK, NULL_MARK, !implicit.isTrue());
+        DocumentEndEvent event = new DocumentEndEvent(!implicit.isTrue(), NULL_MARK, NULL_MARK);
         emit(context, event);
         return this;
     }
@@ -206,17 +201,17 @@ public class PsychEmitter extends RubyObject {
 
         valueStr = EncodingUtils.strConvEnc(context, valueStr, valueStr.getEncoding(), UTF8Encoding.INSTANCE);
 
-        RubyString anchorStr = exportToUTF8(context, anchor, stringClass);
-        RubyString tagStr = exportToUTF8(context, tag, stringClass);
+        String anchorStr = exportToUTF8(context, anchor, stringClass);
+        String tagStr = exportToUTF8(context, tag, stringClass);
 
         ScalarEvent event = new ScalarEvent(
-                anchorStr == null ? null : anchorStr.asJavaString(),
-                tagStr == null ? null : tagStr.asJavaString(),
+                Optional.ofNullable(anchorStr == null ? null : new Anchor(anchorStr)),
+                Optional.ofNullable(tagStr),
                 new ImplicitTuple(plain.isTrue(), quoted.isTrue()),
                 valueStr.asJavaString(),
+                SCALAR_STYLES[style.convertToInteger().getIntValue()],
                 NULL_MARK,
-                NULL_MARK,
-                SCALAR_STYLES[style.convertToInteger().getIntValue()]);
+                NULL_MARK);
 
         emit(context, event);
 
@@ -232,16 +227,16 @@ public class PsychEmitter extends RubyObject {
 
         RubyClass stringClass = context.runtime.getString();
 
-        RubyString anchorStr = exportToUTF8(context, anchor, stringClass);
-        RubyString tagStr = exportToUTF8(context, tag, stringClass);
+        String anchorStr = exportToUTF8(context, anchor, stringClass);
+        String tagStr = exportToUTF8(context, tag, stringClass);
 
         SequenceStartEvent event = new SequenceStartEvent(
-                anchorStr == null ? null : anchorStr.asJavaString(),
-                tagStr == null ? null : tagStr.asJavaString(),
+                Optional.ofNullable(anchorStr == null ? null : new Anchor(anchorStr)),
+                Optional.ofNullable(tagStr),
                 implicit.isTrue(),
+                FLOW_STYLES[style.convertToInteger().getIntValue()],
                 NULL_MARK,
-                NULL_MARK,
-                FLOW_STYLES[style.convertToInteger().getIntValue()]);
+                NULL_MARK);
         emit(context, event);
         return this;
     }
@@ -262,16 +257,16 @@ public class PsychEmitter extends RubyObject {
 
         RubyClass stringClass = context.runtime.getString();
 
-        RubyString anchorStr = exportToUTF8(context, anchor, stringClass);
-        RubyString tagStr = exportToUTF8(context, tag, stringClass);
+        String anchorStr = exportToUTF8(context, anchor, stringClass);
+        String tagStr = exportToUTF8(context, tag, stringClass);
 
         MappingStartEvent event = new MappingStartEvent(
-                anchorStr == null ? null : anchorStr.asJavaString(),
-                tagStr == null ? null : tagStr.asJavaString(),
+                Optional.ofNullable(anchorStr == null ? null : new Anchor(anchorStr)),
+                Optional.ofNullable(tagStr),
                 implicit.isTrue(),
+                FLOW_STYLES[style.convertToInteger().getIntValue()],
                 NULL_MARK,
-                NULL_MARK,
-                FLOW_STYLES[style.convertToInteger().getIntValue()]);
+                NULL_MARK);
 
         emit(context, event);
 
@@ -289,9 +284,9 @@ public class PsychEmitter extends RubyObject {
     public IRubyObject alias(ThreadContext context, IRubyObject anchor) {
         RubyClass stringClass = context.runtime.getString();
 
-        RubyString anchorStr = exportToUTF8(context, anchor, stringClass);
+        String anchorStr = exportToUTF8(context, anchor, stringClass);
 
-        AliasEvent event = new AliasEvent(anchorStr.asJavaString(), NULL_MARK, NULL_MARK);
+        AliasEvent event = new AliasEvent(Optional.of(new Anchor(anchorStr)), NULL_MARK, NULL_MARK);
         emit(context, event);
         return this;
     }
@@ -299,40 +294,40 @@ public class PsychEmitter extends RubyObject {
     @JRubyMethod(name = "canonical=")
     public IRubyObject canonical_set(ThreadContext context, IRubyObject canonical) {
         // TODO: unclear if this affects a running emitter
-        options.setCanonical(canonical.isTrue());
+        dumpSettingsBuilder.setCanonical(canonical.isTrue());
         return canonical;
     }
 
     @JRubyMethod
     public IRubyObject canonical(ThreadContext context) {
         // TODO: unclear if this affects a running emitter
-        return RubyBoolean.newBoolean(context, options.isCanonical());
+        return RubyBoolean.newBoolean(context, buildDumpSettings().isCanonical());
     }
 
     @JRubyMethod(name = "indentation=")
     public IRubyObject indentation_set(ThreadContext context, IRubyObject level) {
         // TODO: unclear if this affects a running emitter
-        options.setIndent((int)level.convertToInteger().getLongValue());
+        dumpSettingsBuilder.setIndent(level.convertToInteger().getIntValue());
         return level;
     }
 
     @JRubyMethod
     public IRubyObject indentation(ThreadContext context) {
         // TODO: unclear if this affects a running emitter
-        return context.runtime.newFixnum(options.getIndent());
+        return context.runtime.newFixnum(buildDumpSettings().getIndent());
     }
 
     @JRubyMethod(name = "line_width=")
     public IRubyObject line_width_set(ThreadContext context, IRubyObject width) {
-        int newWidth = (int)width.convertToInteger().getLongValue();
+        int newWidth = width.convertToInteger().getIntValue();
         if (newWidth <= 0) newWidth = Integer.MAX_VALUE;
-        options.setWidth(newWidth);
+        dumpSettingsBuilder.setWidth(newWidth);
         return width;
     }
 
     @JRubyMethod
     public IRubyObject line_width(ThreadContext context) {
-        return context.runtime.newFixnum(options.getWidth());
+        return context.runtime.newFixnum(buildDumpSettings().getWidth());
     }
 
     private void emit(ThreadContext context, Event event) {
@@ -343,8 +338,6 @@ public class PsychEmitter extends RubyObject {
 
             // flush writer after each emit
             writer.flush();
-        } catch (IOException ioe) {
-            throw context.runtime.newIOErrorFromException(ioe);
         } catch (EmitterException ee) {
             throw context.runtime.newRuntimeError(ee.toString());
         }
@@ -356,41 +349,53 @@ public class PsychEmitter extends RubyObject {
         Encoding encoding = PsychLibrary.YAMLEncoding.values()[(int)_encoding.convertToInteger().getLongValue()].encoding;
         Charset charset = context.runtime.getEncodingService().charsetForEncoding(encoding);
 
-        writer = new OutputStreamWriter(new IOOutputStream(io, encoding), charset);
-        emitter = new Emitter(writer, options);
+        writer = new YamlOutputStreamWriter(new IOOutputStream(io, encoding), charset) {
+            @Override
+            public void processIOException(IOException ioe) {
+                throw context.runtime.newIOErrorFromException(ioe);
+            }
+        };
+        emitter = new Emitter(buildDumpSettings(), writer);
     }
 
-    private RubyString exportToUTF8(ThreadContext context, IRubyObject tag, RubyClass stringClass) {
-        RubyString tagStr = null;
-        if (!tag.isNil()) {
-            TypeConverter.checkType(context, tag, stringClass);
-            tagStr = (RubyString) tag;
-            tagStr = EncodingUtils.strConvEnc(context, tagStr, tagStr.getEncoding(), UTF8Encoding.INSTANCE);
+    private DumpSettings buildDumpSettings() {
+        return dumpSettingsBuilder.build();
+    }
+
+    private String exportToUTF8(ThreadContext context, IRubyObject tag, RubyClass stringClass) {
+        if (tag.isNil()) {
+            return null;
         }
-        return tagStr;
+
+        RubyString tagStr;
+
+        TypeConverter.checkType(context, tag, stringClass);
+        tagStr = (RubyString) tag;
+
+        return EncodingUtils.strConvEnc(context, tagStr, tagStr.getEncoding(), UTF8Encoding.INSTANCE).asJavaString();
     }
 
     Emitter emitter;
-    Writer writer;
-    DumperOptions options = new DumperOptions();
+    StreamDataWriter writer;
+    final DumpSettingsBuilder dumpSettingsBuilder = DumpSettings.builder();
     IRubyObject io;
 
-    private static final Mark NULL_MARK = new Mark("", 0, 0, 0, new int[0], 0);
+    private static final Optional<Mark> NULL_MARK = Optional.empty();
 
     // Map style constants from Psych values (ANY = 0 ... FOLDED = 5)
     // to SnakeYaml values; see psych/nodes/scalar.rb.
-    private static final DumperOptions.ScalarStyle[] SCALAR_STYLES = {
-            DumperOptions.ScalarStyle.PLAIN, // ANY
-            DumperOptions.ScalarStyle.PLAIN,
-            DumperOptions.ScalarStyle.SINGLE_QUOTED,
-            DumperOptions.ScalarStyle.DOUBLE_QUOTED,
-            DumperOptions.ScalarStyle.LITERAL,
-            DumperOptions.ScalarStyle.FOLDED
+    private static final ScalarStyle[] SCALAR_STYLES = {
+            ScalarStyle.PLAIN, // ANY
+            ScalarStyle.PLAIN,
+            ScalarStyle.SINGLE_QUOTED,
+            ScalarStyle.DOUBLE_QUOTED,
+            ScalarStyle.LITERAL,
+            ScalarStyle.FOLDED
     };
 
-    private static final DumperOptions.FlowStyle[] FLOW_STYLES = {
-            DumperOptions.FlowStyle.AUTO,
-            DumperOptions.FlowStyle.BLOCK,
-            DumperOptions.FlowStyle.FLOW
+    private static final FlowStyle[] FLOW_STYLES = {
+            FlowStyle.AUTO,
+            FlowStyle.BLOCK,
+            FlowStyle.FLOW
     };
 }

--- a/ext/java/org/jruby/ext/psych/PsychLibrary.java
+++ b/ext/java/org/jruby/ext/psych/PsychLibrary.java
@@ -27,10 +27,6 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ext.psych;
 
-import java.io.InputStream;
-import java.io.IOException;
-import java.util.Properties;
-
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF16BEEncoding;
 import org.jcodings.specific.UTF16LEEncoding;
@@ -44,7 +40,10 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
-import org.yaml.snakeyaml.error.Mark;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class PsychLibrary implements Library {
     private static final String DUMMY_VERSION = "0.0";
@@ -54,7 +53,7 @@ public class PsychLibrary implements Library {
 
         // load version from properties packed with the jar
         Properties props = new Properties();
-        try( InputStream is = runtime.getJRubyClassLoader().getResourceAsStream("META-INF/maven/org.yaml/snakeyaml/pom.properties") ) {
+        try( InputStream is = runtime.getJRubyClassLoader().getResourceAsStream("META-INF/maven/org.snakeyaml/snakeyaml-engine/pom.properties") ) {
             props.load(is);
         }
         catch( IOException e ) {
@@ -64,27 +63,6 @@ public class PsychLibrary implements Library {
 
         if (snakeyamlVersion.endsWith("-SNAPSHOT")) {
             snakeyamlVersion = snakeyamlVersion.substring(0, snakeyamlVersion.length() - "-SNAPSHOT".length());
-        }
-
-        // Try to determine if we have a new enough SnakeYAML.
-        // Versions before 1.21 removed a Mark constructor that JRuby uses.
-        // See https://github.com/bundler/bundler/issues/6878
-        if (snakeyamlVersion.equals(DUMMY_VERSION)) {
-            try {
-                // Use reflection to try to confirm we have a new enough version
-                Mark.class.getConstructor(String.class, int.class, int.class, int.class, int[].class, int.class);
-            } catch (NoSuchMethodException nsme) {
-                throw runtime.newLoadError("bad SnakeYAML version, required 1.21 or higher; check your CLASSPATH for a conflicting jar");
-            }
-        } else {
-            // Parse version string to check for 1.21+
-            String[] majorMinor = snakeyamlVersion.split("\\.");
-
-            if (majorMinor.length < 2 || Integer.parseInt(majorMinor[0]) < 1 || Integer.parseInt(majorMinor[1]) < 21) {
-                throw runtime.newLoadError(
-                        "bad SnakeYAML version " + snakeyamlVersion +
-                                ", required 1.21 or higher; check your CLASSPATH for a conflicting jar");
-            }
         }
 
         RubyString version = runtime.newString(snakeyamlVersion + ".0");

--- a/ext/java/org/jruby/ext/psych/PsychParser.java
+++ b/ext/java/org/jruby/ext/psych/PsychParser.java
@@ -305,10 +305,11 @@ public class PsychParser extends RubyObject {
     
     private void handleDocumentStart(ThreadContext context, DocumentStartEvent dse, IRubyObject handler) {
         Ruby runtime = context.runtime;
-        SpecVersion _version = dse.getSpecVersion().orElse(new SpecVersion(1, 2));
-        IRubyObject version = _version == null ?
-            RubyArray.newArray(runtime) :
-            RubyArray.newArray(runtime, runtime.newFixnum(_version.getMajor()), runtime.newFixnum(_version.getMinor()));
+
+        Optional<SpecVersion> specVersion = dse.getSpecVersion();
+        IRubyObject version = specVersion.isPresent() ?
+                RubyArray.newArray(runtime, runtime.newFixnum(specVersion.get().getMajor()), runtime.newFixnum(specVersion.get().getMinor())) :
+                RubyArray.newEmptyArray(runtime);
 
         Map<String, String> tagsMap = dse.getTags();
         RubyArray tags = RubyArray.newArray(runtime);

--- a/ext/java/org/jruby/ext/psych/PsychToRuby.java
+++ b/ext/java/org/jruby/ext/psych/PsychToRuby.java
@@ -29,14 +29,15 @@ package org.jruby.ext.psych;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyException;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
-import org.jruby.RubyException;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import static org.jruby.runtime.Visibility.*;
+
+import static org.jruby.runtime.Visibility.PRIVATE;
 
 public class PsychToRuby {
     public static void initPsychToRuby(Ruby runtime, RubyModule psych) {

--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -5,6 +5,6 @@ module Psych
   VERSION = '5.0.1'
 
   if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '1.33'.freeze
+    DEFAULT_SNAKEYAML_VERSION = '2.6'.freeze
   end
 end

--- a/lib/psych_jars.rb
+++ b/lib/psych_jars.rb
@@ -2,4 +2,4 @@
 require 'psych.jar'
 
 require 'jar-dependencies'
-require_jar('org.yaml', 'snakeyaml', Psych::DEFAULT_SNAKEYAML_VERSION)
+require_jar('org.snakeyaml', 'snakeyaml-engine', Psych::DEFAULT_SNAKEYAML_VERSION)

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -52,11 +52,10 @@ DESCRIPTION
       "ext/java/org/jruby/ext/psych/PsychLibrary.java",
       "ext/java/org/jruby/ext/psych/PsychParser.java",
       "ext/java/org/jruby/ext/psych/PsychToRuby.java",
-      "ext/java/org/jruby/ext/psych/PsychYamlTree.java",
       "lib/psych_jars.rb",
       "lib/psych.jar"
     ]
-    s.requirements = "jar org.yaml:snakeyaml, #{version_module::Psych::DEFAULT_SNAKEYAML_VERSION}"
+    s.requirements = "jar org.snakeyaml:snakeyaml-engine, #{version_module::Psych::DEFAULT_SNAKEYAML_VERSION}"
     s.add_dependency 'jar-dependencies', '>= 0.1.7'
   else
     s.extensions = ["ext/psych/extconf.rb"]

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -223,8 +223,8 @@ EOY
     &C currency: GBP
     &D departure: LAX
     &A arrival: EDI
-  - { *F: MADF, *C: AUD, *D: SYD, *A: MEL }
-  - { *F: DFSF, *C: USD, *D: JFK, *A: MCO }
+  - { *F : MADF, *C : AUD, *D : SYD, *A : MEL }
+  - { *F : DFSF, *C : USD, *D : JFK, *A : MCO }
 EOY
         )
 
@@ -233,20 +233,20 @@ EOY
 ---
 ALIASES: [&f fareref, &c currency, &d departure, &a arrival]
 FARES:
-- *f: DOGMA
-  *c: GBP
-  *d: LAX
-  *a: EDI
+- *f : DOGMA
+  *c : GBP
+  *d : LAX
+  *a : EDI
 
-- *f: MADF
-  *c: AUD
-  *d: SYD
-  *a: MEL
+- *f : MADF
+  *c : AUD
+  *d : SYD
+  *a : MEL
 
-- *f: DFSF
-  *c: USD
-  *d: JFK
-  *a: MCO
+- *f : DFSF
+  *c : USD
+  *d : JFK
+  *a : MCO
 
 EOY
         )


### PR DESCRIPTION
See jruby/jruby#7570 for some of the justification for this move. We only require the parser from SnakeYAML, but in the original form it is encumbered with Java object serialization code that keeps getting flagged as a CVE risk. We disagree with the assessment, at least as it pertains to JRuby (we do not use the code in question) but our inclusion of the library continues to get flagged by auditing tools.

This PR starts the process of moving to the successor library, SnakeYAML Engine. The parser API is largely unchanged, except as seen in this commit. No Java exceptions are thrown, but a number of Psych tests fail (possibly due to Engine being YAML 1.2 only).