### PR TITLE
configure of libyaml couldn't detect "arm64-apple-darwin22" for build host

### DIFF
--- a/ext/psych/extconf.rb
+++ b/ext/psych/extconf.rb
@@ -22,7 +22,7 @@ if yaml_source
   args = [
     yaml_configure,
     "--enable-#{shared ? 'shared' : 'static'}",
-    "--host=#{RbConfig::CONFIG['host'].sub(/-unknown-/, '-')}",
+    "--host=#{RbConfig::CONFIG['host'].sub(/-unknown-/, '-').sub(/arm64/, 'arm')}",
     "CC=#{RbConfig::CONFIG['CC']}",
     *(["CFLAGS=-w"] if RbConfig::CONFIG["GCC"] == "yes"),
   ]


### PR DESCRIPTION
Fixed https://github.com/ruby/psych/discussions/615


```
  checking whether make sets $(MAKE)... (cached) yes
  checking build system type... arm-apple-darwin21.6.0
  checking host system type... Invalid configuration `arm64-apple-darwin21': machine `arm64-apple' not recognized
  configure: error: /bin/sh /Users/hsbt/Downloads/yaml-0.2.5/config/config.sub arm64-apple-darwin21 failed
  *** extconf.rb failed ***
```