### PR TITLE
Add :stringify_names option to convert symbol keys to string for dumping

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -489,6 +489,10 @@ module Psych
   #
   #                           Default: <tt>false</tt>.
   #
+  # [<tt>:stringify_names</tt>] Dump symbol keys in Hash objects as string.
+  #
+  #                             Default: <tt>false</tt>.
+  #
   # Example:
   #
   #   # Dump an array, get back a YAML string
@@ -502,6 +506,9 @@ module Psych
   #
   #   # Dump an array to an IO with indentation set
   #   Psych.dump(['a', ['b']], StringIO.new, indentation: 3)
+  #
+  #   # Dump hash with symbol keys as string
+  #   Psych.dump({a: "b"}, stringify_names: true) # => "---\na: b\n"
   def self.dump o, io = nil, options = {}
     if Hash === io
       options = io
@@ -562,6 +569,10 @@ module Psych
   #
   #                           Default: <tt>false</tt>.
   #
+  # [<tt>:stringify_names</tt>] Dump symbol keys in Hash objects as string.
+  #
+  #                             Default: <tt>false</tt>.
+  #
   # Example:
   #
   #   # Dump an array, get back a YAML string
@@ -575,6 +586,9 @@ module Psych
   #
   #   # Dump an array to an IO with indentation set
   #   Psych.safe_dump(['a', ['b']], StringIO.new, indentation: 3)
+  #
+  #   # Dump hash with symbol keys as string
+  #   Psych.dump({a: "b"}, stringify_names: true) # => "---\na: b\n"
   def self.safe_dump o, io = nil, options = {}
     if Hash === io
       options = io

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -70,6 +70,7 @@ module Psych
             fail(ArgumentError, "Invalid line_width #{@line_width}, must be non-negative or -1 for unlimited.")
           end
         end
+        @stringify_names = options[:stringify_names]
         @coders     = []
 
         @dispatch_cache = Hash.new do |h,klass|
@@ -328,7 +329,7 @@ module Psych
         if o.class == ::Hash
           register(o, @emitter.start_mapping(nil, nil, true, Psych::Nodes::Mapping::BLOCK))
           o.each do |k,v|
-            accept k
+            accept(@stringify_names && Symbol === k ? k.to_s : k)
             accept v
           end
           @emitter.end_mapping
@@ -341,7 +342,7 @@ module Psych
         register(o, @emitter.start_mapping(nil, '!set', false, Psych::Nodes::Mapping::BLOCK))
 
         o.each do |k,v|
-          accept k
+          accept(@stringify_names && Symbol === k ? k.to_s : k)
           accept v
         end
 

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -430,6 +430,32 @@ eoyml
     assert_match(/\A--- :foo\n(?:\.\.\.\n)?\z/, Psych.safe_dump(:foo, permitted_symbols: [:foo]))
   end
 
+  def test_safe_dump_stringify_names
+    yaml = <<-eoyml
+---
+foo:
+  bar: bar
+  'no': special escapes
+  123: number
+eoyml
+
+    payload = Psych.safe_dump({
+      foo: {
+        bar: "bar",
+        no: "special escapes",
+        123 => "number"
+      }
+    }, stringify_names: true)
+    assert_equal yaml, payload
+
+    assert_equal("---\nfoo: :bar\n", Psych.safe_dump({foo: :bar}, stringify_names: true, permitted_symbols: [:bar]))
+
+    error = assert_raise Psych::DisallowedClass do
+      Psych.safe_dump({foo: :bar}, stringify_names: true)
+    end
+    assert_equal "Tried to dump unspecified class: Symbol(:bar)", error.message
+  end
+
   def test_safe_dump_aliases
     x = []
     x << x

--- a/test/psych/test_set.rb
+++ b/test/psych/test_set.rb
@@ -46,5 +46,12 @@ bar: baz
       @set['self'] = @set
       assert_cycle(@set)
     end
+
+    def test_stringify_names
+      @set[:symbol] = :value
+
+      assert_match(/^:symbol: :value/, Psych.dump(@set))
+      assert_match(/^symbol: :value/, Psych.dump(@set, stringify_names: true))
+    end
   end
 end


### PR DESCRIPTION
When dumping larger and/or nested Hashes, it would be useful to let Psych treat symbol keys as string keys to avoid building a new hash with string keys, just for the sake of dumping.

`:stringify_names` for dumping is conceptually the reverse of `:symbolize_names` for loading:

```ruby
yaml = "---\nfoo: bar\n"
Psych.dump(Psych.load(yaml, symbolize_names: true), stringify_names: true) == yaml # => true
```