### PR TITLE
Prefer `assert_include` for simple strings

### DIFF
--- a/test/psych/visitors/test_emitter.rb
+++ b/test/psych/visitors/test_emitter.rb
@@ -61,9 +61,9 @@ module Psych
 
         @visitor.accept s
 
-        assert_match(/key: value/, @io.string)
+        assert_include(@io.string, "key: value")
         assert_equal @io.string, s.yaml
-        assert(/\.\.\./ !~ s.yaml)
+        assert_not_include(s.yaml, "...")
       end
 
       def test_scalar
@@ -76,7 +76,7 @@ module Psych
 
         @visitor.accept s
 
-        assert_match(/hello/, @io.string)
+        assert_include(@io.string, "hello")
         assert_equal @io.string, s.yaml
       end
 
@@ -90,8 +90,8 @@ module Psych
 
         @visitor.accept s
 
-        assert_match(/str/, @io.string)
-        assert_match(/hello/, @io.string)
+        assert_include(@io.string, "str")
+        assert_include(@io.string, "hello")
         assert_equal @io.string, s.yaml
       end
 
@@ -107,7 +107,7 @@ module Psych
 
         @visitor.accept s
 
-        assert_match(/- hello/, @io.string)
+        assert_include(@io.string, "- hello")
         assert_equal @io.string, s.yaml
       end
 
@@ -122,7 +122,7 @@ module Psych
 
         @visitor.accept s
 
-        assert_match(/key: value/, @io.string)
+        assert_include(@io.string, "key: value")
         assert_equal @io.string, s.yaml
       end
 
@@ -137,7 +137,7 @@ module Psych
 
         @visitor.accept s
 
-        assert_match(/&A key: \*A/, @io.string)
+        assert_include(@io.string, "&A key: \*A")
         assert_equal @io.string, s.yaml
       end
     end

--- a/test/psych/visitors/test_yaml_tree.rb
+++ b/test/psych/visitors/test_yaml_tree.rb
@@ -34,7 +34,7 @@ module Psych
         v << "hello world"
         v.finish
 
-        assert_match "hello world", io.string
+        assert_include io.string, "hello world"
       end
 
       def test_binary_formatting
@@ -167,9 +167,9 @@ module Psych
       end
 
       def test_string
-        assert_match(/'017'/, Psych.dump({'a' => '017'}))
-        assert_match(/'019'/, Psych.dump({'a' => '019'}))
-        assert_match(/'01818'/, Psych.dump({'a' => '01818'}))
+        assert_include(Psych.dump({'a' => '017'}), "'017'")
+        assert_include(Psych.dump({'a' => '019'}), "'019'")
+        assert_include(Psych.dump({'a' => '01818'}), "'01818'")
       end
 
       # http://yaml.org/type/null.html


### PR DESCRIPTION
Using regexps unnecessarily sometimes leads to mistakes, like #628.