### PR TITLE
issue #443: quote Y and N when dumping

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -272,7 +272,7 @@ module Psych
           tag   = 'tag:yaml.org,2002:str'
           plain = false
           quote = false
-        elsif o == 'y' || o == 'n'
+        elsif o == 'y' || o == 'Y' || o == 'n' || o == 'N'
           style = Nodes::Scalar::DOUBLE_QUOTED
         elsif @line_width && o.length > @line_width
           style = Nodes::Scalar::FOLDED

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -24,10 +24,19 @@ module Psych
     # "ambiguity" in the emitted document
     def test_y_is_quoted
       assert_match(/"y"/, Psych.dump("y"))
+      assert_match(/"Y"/, Psych.dump("Y"))
     end
 
     def test_n_is_quoted
       assert_match(/"n"/, Psych.dump("n"))
+      assert_match(/"N"/, Psych.dump("N"))
+    end
+
+    def test_all_yaml_1_1_booleans_are_quoted
+      yaml_1_1_booleans = %w[y Y yes Yes YES n N no No NO true True TRUE false False FALSE on On ON off Off OFF] # from https://yaml.org/type/bool.html
+      yaml_1_1_booleans.each do |boolean|
+        assert_match(/"#{boolean}"|'#{boolean}'/, Psych.dump(boolean))
+      end
     end
 
     def test_string_with_newline

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -17,20 +17,11 @@ module Psych
       end
     end
 
-    # 'y' and 'n' are kind of ambiguous.  Syck treated y and n literals in
+    # 'y', 'Y', 'n', 'N' are kind of ambiguous.  Syck treated those literals in
     # YAML documents as strings.  But this is not what the YAML 1.1 spec says.
     # YAML 1.1 says they should be treated as booleans.  When we're dumping
     # documents, we know it's a string, so adding quotes will eliminate the
     # "ambiguity" in the emitted document
-    def test_y_is_quoted
-      assert_match(/"y"/, Psych.dump("y"))
-      assert_match(/"Y"/, Psych.dump("Y"))
-    end
-
-    def test_n_is_quoted
-      assert_match(/"n"/, Psych.dump("n"))
-      assert_match(/"N"/, Psych.dump("N"))
-    end
 
     def test_all_yaml_1_1_booleans_are_quoted
       yaml_1_1_booleans = %w[y Y yes Yes YES n N no No NO true True TRUE false False FALSE on On ON off Off OFF] # from https://yaml.org/type/bool.html


### PR DESCRIPTION
Building on https://github.com/ruby/psych/pull/515, this has the uppercase fixes as well for https://github.com/ruby/psych/issues/443.
