### PR TITLE
Move the responsibility of safe loading to Node

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -319,20 +319,10 @@ module Psych
   #   Psych.safe_load("---\n foo: bar")                         # => {"foo"=>"bar"}
   #   Psych.safe_load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
-  def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
+  def self.safe_load yaml, filename: nil, fallback: nil, **kwargs
     result = parse(yaml, filename: filename)
     return fallback unless result
-
-    class_loader = ClassLoader::Restricted.new(permitted_classes.map(&:to_s),
-                                               permitted_symbols.map(&:to_s))
-    scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer
-    visitor = if aliases
-                Visitors::ToRuby.new scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze
-              else
-                Visitors::NoAliasRuby.new scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze
-              end
-    result = visitor.accept result
-    result
+    result.to_safe_ruby(**kwargs)
   end
 
   ###

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -52,6 +52,23 @@ module Psych
       alias :transform :to_ruby
 
       ###
+      # Safely convert this node to Ruby.
+      #
+      # See also Psych.safe_load
+      #
+      def to_safe_ruby(permitted_classes: [], permitted_symbols: [], aliases: false, symbolize_names: false, freeze: false, strict_integer: false)
+        class_loader = ClassLoader::Restricted.new(
+          permitted_classes.map(&:to_s),
+          permitted_symbols.map(&:to_s)
+        )
+        scanner = ScalarScanner.new(class_loader, strict_integer: strict_integer)
+        visitor_class = aliases ? Visitors::ToRuby : Visitors::NoAliasRuby
+
+        visitor_class.new(scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze).accept(self)
+      end
+      alias :safe_transform :to_safe_ruby
+
+      ###
       # Convert this node to YAML.
       #
       # See also Psych::Visitors::Emitter


### PR DESCRIPTION
This change moves the responsibility of safely loading a YAML tree from an internal detail of `Psych.safe_load` into `Psych::Nodes::Node`.

The advantage of this is that you can now more easily safely load trees that you're working on without replicating the safety constraints of `Psych.safe_load`. The delegation of responsibilities also now matches for safely and unsafely loading a tree.

I opted for two choices to make the diff smaller:

1. I left all of the documentation on `Psych.safe_load` instead of moving it to `Psych::Nodes::Node#to_safe_ruby`. The main reason I chose to do so is that `Psych.safe_load` is the most likely entry point into using Psych for most people, so having the documentation on that method makes sense.
2. I delegated responsibility for the default arguments to `Psych::Nodes::Node` rather than duplicating them. The reason I chose to do this was to reduce the chance of two lists of arguments becoming unsynchronized. Additionally, since the behavior actually belongs to `Psych::Nodes::Node` now, it's the only place that can have the defaults set for all use cases.