### PR TITLE
Prefer each_char in Psych::Visitors::Visitor::ToRuby#deserialize

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -101,7 +101,7 @@ module Psych
           source  = $1
           options = 0
           lang    = nil
-          ($2 || '').split('').each do |option|
+          $2&.each_char do |option|
             case option
             when 'x' then options |= Regexp::EXTENDED
             when 'i' then options |= Regexp::IGNORECASE


### PR DESCRIPTION
Use safe navigation operator with each_char to remove empty strings and improve readability.