### PR TITLE
`YAMLTree` performance by not using `object_id`s

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -15,30 +15,29 @@ module Psych
     class YAMLTree < Psych::Visitors::Visitor
       class Registrar # :nodoc:
         def initialize
-          @obj_to_id   = {}
-          @obj_to_node = {}
+          @obj_to_id   = {}.compare_by_identity
+          @obj_to_node = {}.compare_by_identity
           @targets     = []
           @counter     = 0
         end
 
         def register target, node
-          return unless target.respond_to? :object_id
           @targets << target
-          @obj_to_node[target.object_id] = node
+          @obj_to_node[target] = node
         end
 
         def key? target
-          @obj_to_node.key? target.object_id
+          @obj_to_node.key? target
         rescue NoMethodError
           false
         end
 
         def id_for target
-          @obj_to_id[target.object_id] ||= (@counter += 1)
+          @obj_to_id[target] ||= (@counter += 1)
         end
 
         def node_for target
-          @obj_to_node[target.object_id]
+          @obj_to_node[target]
         end
       end
 

--- a/test/psych/test_object_references.rb
+++ b/test/psych/test_object_references.rb
@@ -39,7 +39,7 @@ module Psych
       rescue Psych::DisallowedClass
         data = Psych.unsafe_load yml
       end
-      assert_equal data.first.object_id, data.last.object_id
+      assert_same data.first, data.last
     end
 
     def test_float_references
@@ -49,7 +49,7 @@ module Psych
 - *name
       eoyml
       assert_equal data.first, data.last
-      assert_equal data.first.object_id, data.last.object_id
+      assert_same data.first, data.last
     end
 
     def test_binary_references
@@ -60,7 +60,7 @@ module Psych
 - *name
       eoyml
       assert_equal data.first, data.last
-      assert_equal data.first.object_id, data.last.object_id
+      assert_same data.first, data.last
     end
 
     def test_regexp_references
@@ -70,7 +70,7 @@ module Psych
 - *name
       eoyml
       assert_equal data.first, data.last
-      assert_equal data.first.object_id, data.last.object_id
+      assert_same data.first, data.last
     end
   end
 end

--- a/test/psych/visitors/test_to_ruby.rb
+++ b/test/psych/visitors/test_to_ruby.rb
@@ -319,7 +319,7 @@ description:
 
         list = seq.to_ruby
         assert_equal %w{ foo foo }, list
-        assert_equal list[0].object_id, list[1].object_id
+        assert_same list[0], list[1]
       end
 
       def test_mapping_with_str_tag


### PR DESCRIPTION
Since Ruby 2.7, `object_id` became more expensive, particularly on its first call for a particular object. @JemmaIssroff has a great [blog post](https://jemma.dev/blog/gc-object-id) about it.

We can reduce how many objects we assign object IDs to, by using `Hash#compare_by_identity` in the `YAMLTree::Registrar`. The semantics will be the same, but now loads/stores into the Hash are faster, and we don't need to trigger lots of object ID assignments.

On a related note, I used `assert_same` in the tests, where applicable (instead of `assert_equal a.object_id, b.object_id`).

Is there a benchmark suite I can run to compare before/after performance?