### PR TITLE
Remove unused array

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -26,8 +26,6 @@ module Psych
 
         def key? target
           @obj_to_node.key? target
-        rescue NoMethodError
-          false
         end
 
         def id_for target

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -17,12 +17,10 @@ module Psych
         def initialize
           @obj_to_id   = {}.compare_by_identity
           @obj_to_node = {}.compare_by_identity
-          @targets     = []
           @counter     = 0
         end
 
         def register target, node
-          @targets << target
           @obj_to_node[target] = node
         end
 


### PR DESCRIPTION
I noticed in #663 that the `@targets` ivar in `Psych::YAMLTree::Registrar` is only ever written into, and never read.