### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/psych

### DIFF
--- a/psych.gemspec
+++ b/psych.gemspec
@@ -76,5 +76,5 @@ DESCRIPTION
   end
 
   s.metadata['msys2_mingw_dependencies'] = 'libyaml'
-
+  s.metadata['changelog_uri'] = s.homepage + '/releases'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/psych which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/