### PR TITLE
docs: specify correct default `fallback` value

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -340,7 +340,7 @@ module Psych
   # provided, the object contained in the first document will be returned.
   # +filename+ will be used in the exception message if any exception
   # is raised while parsing.  If +yaml+ is empty, it returns
-  # the specified +fallback+ return value, which defaults to +false+.
+  # the specified +fallback+ return value, which defaults to +nil+.
   #
   # Raises a Psych::SyntaxError when a YAML syntax error is detected.
   #
@@ -667,7 +667,7 @@ module Psych
   ###
   # Safely loads the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
-  # the specified +fallback+ return value, which defaults to +false+.
+  # the specified +fallback+ return value, which defaults to +nil+.
   # See safe_load for options.
   def self.safe_load_file filename, **kwargs
     File.open(filename, 'r:bom|utf-8') { |f|
@@ -678,7 +678,7 @@ module Psych
   ###
   # Loads the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
-  # the specified +fallback+ return value, which defaults to +false+.
+  # the specified +fallback+ return value, which defaults to +nil+.
   # See load for options.
   def self.load_file filename, **kwargs
     File.open(filename, 'r:bom|utf-8') { |f|


### PR DESCRIPTION
It seems that only `unsafe_load` defaults to `false` for `fallback` - the other methods default to `nil`.

I assume that ideally `unsafe_load` should be changed but looking over #358 & co it seems like there's a bit of a hairy history so maybe that ship has sailed...