### PR TITLE
Unlimited line_width with -1

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -479,6 +479,7 @@ module Psych
   #
   #                           Default: <tt>2</tt>.
   # [<tt>:line_width</tt>]    Max character to wrap line at.
+  #                           For unlimited line width use <tt>-1</tt>.
   #
   #                           Default: <tt>0</tt> (meaning "wrap at 81").
   # [<tt>:canonical</tt>]     Write "canonical" YAML form (very verbose, yet
@@ -559,6 +560,7 @@ module Psych
   #
   #                           Default: <tt>2</tt>.
   # [<tt>:line_width</tt>]    Max character to wrap line at.
+  #                           For unlimited line width use <tt>-1</tt>.
   #
   #                           Default: <tt>0</tt> (meaning "wrap at 81").
   # [<tt>:canonical</tt>]     Write "canonical" YAML form (very verbose, yet


### PR DESCRIPTION
This PR just documents the behavior of using `-1` as `line_width` when calling `Psych.dump`/`Object#to_yaml`. 
It is [mentioned in the code](https://github.com/ruby/psych/blob/master/lib/psych/visitors/yaml_tree.rb#L62) but not in the docs.