### PR TITLE
Add .git-blame-ignore-revs to ignore expanding tabs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Expand tabs
+e7d64c9848e76d848cbf316bc19674ffe169b1e7


### PR DESCRIPTION
Ignore commit e7d64c9848e76d848cbf316bc19674ffe169b1e7 in git blames.

Before:

<img width="1132" alt="Screenshot 2024-08-09 at 2 43 07 PM" src="https://github.com/user-attachments/assets/6b59d570-99e3-43f6-98c6-826d1e633ecc">


After:

<img width="1126" alt="Screenshot 2024-08-09 at 2 43 50 PM" src="https://github.com/user-attachments/assets/44c8c421-355a-4188-aa40-7992def7c022">
