### PR TITLE
Data object encoding

### DIFF
--- a/ext/psych/psych_to_ruby.c
+++ b/ext/psych/psych_to_ruby.c
@@ -24,6 +24,15 @@ static VALUE path2class(VALUE self, VALUE path)
     return rb_path_to_class(path);
 }
 
+static VALUE init_struct(VALUE self, VALUE data, VALUE attrs)
+{
+    VALUE args = rb_ary_new2(1);
+    rb_ary_push(args, attrs);
+    rb_struct_initialize(data, args);
+
+    return data;
+}
+
 void Init_psych_to_ruby(void)
 {
     VALUE psych     = rb_define_module("Psych");
@@ -33,6 +42,7 @@ void Init_psych_to_ruby(void)
     VALUE visitor   = rb_define_class_under(visitors, "Visitor", rb_cObject);
     cPsychVisitorsToRuby = rb_define_class_under(visitors, "ToRuby", visitor);
 
+    rb_define_private_method(cPsychVisitorsToRuby, "init_struct", init_struct, 2);
     rb_define_private_method(cPsychVisitorsToRuby, "build_exception", build_exception, 2);
     rb_define_private_method(class_loader, "path2class", path2class, 1);
 }

--- a/lib/psych/class_loader.rb
+++ b/lib/psych/class_loader.rb
@@ -6,6 +6,7 @@ module Psych
   class ClassLoader # :nodoc:
     BIG_DECIMAL = 'BigDecimal'
     COMPLEX     = 'Complex'
+    DATA        = 'Data' unless RUBY_VERSION < "3.2"
     DATE        = 'Date'
     DATE_TIME   = 'DateTime'
     EXCEPTION   = 'Exception'

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -219,7 +219,8 @@ module Psych
             revive_data_members(members, o)
           end
           data ||= allocate_anon_data(o, members)
-          data.send(:initialize, **members)
+          init_struct(data, **members)
+          data.freeze
           data
 
         when /^!ruby\/object:?(.*)?$/

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -162,6 +162,16 @@ module Psych
 
       alias :visit_Delegator :visit_Object
 
+      def visit_Data o
+        tag = ['!ruby/data', o.class.name].compact.join(':')
+        register o, @emitter.start_mapping(nil, tag, false, Nodes::Mapping::BLOCK)
+        o.members.each do |member|
+          @emitter.scalar member.to_s, nil, nil, true, false, Nodes::Scalar::ANY
+          accept o.send member
+        end
+        @emitter.end_mapping
+      end
+
       def visit_Struct o
         tag = ['!ruby/struct', o.class.name].compact.join(':')
 

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -163,13 +163,41 @@ module Psych
       alias :visit_Delegator :visit_Object
 
       def visit_Data o
-        tag = ['!ruby/data', o.class.name].compact.join(':')
-        register o, @emitter.start_mapping(nil, tag, false, Nodes::Mapping::BLOCK)
-        o.members.each do |member|
-          @emitter.scalar member.to_s, nil, nil, true, false, Nodes::Scalar::ANY
-          accept o.send member
+        ivars = o.instance_variables
+        if ivars.empty?
+          tag = ['!ruby/data', o.class.name].compact.join(':')
+          register o, @emitter.start_mapping(nil, tag, false, Nodes::Mapping::BLOCK)
+          o.members.each do |member|
+            @emitter.scalar member.to_s, nil, nil, true, false, Nodes::Scalar::ANY
+            accept o.send member
+          end
+          @emitter.end_mapping
+
+        else
+          tag = ['!ruby/data-with-ivars', o.class.name].compact.join(':')
+          node = @emitter.start_mapping(nil, tag, false, Psych::Nodes::Mapping::BLOCK)
+          register(o, node)
+
+          # Dump the members
+          accept 'members'
+          @emitter.start_mapping nil, nil, true, Nodes::Mapping::BLOCK
+          o.members.each do |member|
+            @emitter.scalar member.to_s, nil, nil, true, false, Nodes::Scalar::ANY
+            accept o.send member
+          end
+          @emitter.end_mapping
+
+          # Dump the ivars
+          accept 'ivars'
+          @emitter.start_mapping nil, nil, true, Nodes::Mapping::BLOCK
+          ivars.each do |ivar|
+            accept ivar.to_s
+            accept o.instance_variable_get ivar
+          end
+          @emitter.end_mapping
+
+          @emitter.end_mapping
         end
-        @emitter.end_mapping
       end
 
       def visit_Struct o

--- a/test/psych/test_data.rb
+++ b/test/psych/test_data.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+class PsychDataWithIvar < Data.define(:foo)
+  attr_reader :bar
+  def initialize(**)
+    @bar = 'hello'
+    super
+  end
+end unless RUBY_VERSION < "3.2"
+
+module Psych
+  class TestData < TestCase
+    class SelfReferentialData < Data.define(:foo)
+      attr_accessor :ref
+      def initialize(foo:)
+        @ref = self
+        super
+      end
+    end unless RUBY_VERSION < "3.2"
+
+    def setup
+      omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+    end
+
+    # TODO: move to another test?
+    def test_dump_data
+      assert_equal <<~eoyml, Psych.dump(PsychDataWithIvar["bar"])
+        --- !ruby/data-with-ivars:PsychDataWithIvar
+        members:
+          foo: bar
+        ivars:
+          "@bar": hello
+      eoyml
+    end
+
+    def test_self_referential_data
+      circular = SelfReferentialData.new("foo")
+
+      loaded = Psych.unsafe_load(Psych.dump(circular))
+      assert_instance_of(SelfReferentialData, loaded.ref)
+
+      assert_equal(circular, loaded)
+      assert_same(loaded, loaded.ref)
+    end
+
+    def test_roundtrip
+      thing = PsychDataWithIvar.new("bar")
+      data = Psych.unsafe_load(Psych.dump(thing))
+
+      assert_equal "hello", data.bar
+      assert_equal "bar",   data.foo
+    end
+
+    def test_load
+      obj = Psych.unsafe_load(<<~eoyml)
+        --- !ruby/data-with-ivars:PsychDataWithIvar
+        members:
+          foo: bar
+        ivars:
+          "@bar": hello
+      eoyml
+
+      assert_equal "hello", obj.bar
+      assert_equal "bar",   obj.foo
+    end
+  end
+end
+

--- a/test/psych/test_object_references.rb
+++ b/test/psych/test_object_references.rb
@@ -31,6 +31,11 @@ module Psych
       assert_reference_trip Struct.new(:foo).new(1)
     end
 
+    def test_data_has_references
+      omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+      assert_reference_trip Data.define(:foo).new(1)
+    end
+
     def assert_reference_trip obj
       yml = Psych.dump([obj, obj])
       assert_match(/\*-?\d+/, yml)

--- a/test/psych/test_safe_load.rb
+++ b/test/psych/test_safe_load.rb
@@ -114,6 +114,38 @@ module Psych
       end
     end
 
+    D = Data.define(:d) unless RUBY_VERSION < "3.2"
+
+    def test_data_depends_on_sym
+      omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+      assert_safe_cycle(D.new(nil), permitted_classes: [D, Symbol])
+      assert_raise(Psych::DisallowedClass) do
+        cycle D.new(nil), permitted_classes: [D]
+      end
+    end
+
+    def test_anon_data
+      omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+      assert Psych.safe_load(<<-eoyml, permitted_classes: [Data, Symbol])
+--- !ruby/data
+  foo: bar
+      eoyml
+
+      assert_raise(Psych::DisallowedClass) do
+        Psych.safe_load(<<-eoyml, permitted_classes: [Data])
+--- !ruby/data
+  foo: bar
+        eoyml
+      end
+
+      assert_raise(Psych::DisallowedClass) do
+        Psych.safe_load(<<-eoyml, permitted_classes: [Symbol])
+--- !ruby/data
+  foo: bar
+        eoyml
+      end
+    end
+
     def test_safe_load_default_fallback
       assert_nil Psych.safe_load("")
     end

--- a/test/psych/test_serialize_subclasses.rb
+++ b/test/psych/test_serialize_subclasses.rb
@@ -35,5 +35,23 @@ module Psych
       so = StructSubclass.new('foo', [1,2,3])
       assert_equal so, Psych.unsafe_load(Psych.dump(so))
     end
+
+    class DataSubclass < Data.define(:foo)
+      def initialize(foo:)
+        @bar = "hello #{foo}"
+        super(foo: foo)
+      end
+
+      def == other
+        super(other) && @bar == other.instance_eval{ @bar }
+      end
+    end unless RUBY_VERSION < "3.2"
+
+    def test_data_subclass
+      omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+      so = DataSubclass.new('foo')
+      assert_equal so, Psych.unsafe_load(Psych.dump(so))
+    end
+
   end
 end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -6,6 +6,7 @@ require_relative 'helper'
 # [ruby-core:01946]
 module Psych_Tests
     StructTest = Struct::new( :c )
+    DataTest   = Data.define( :c ) unless RUBY_VERSION < "3.2"
 end
 
 class Psych_Unit_Tests < Psych::TestCase
@@ -1066,6 +1067,44 @@ EOY
 
         assert_to_yaml( Psych_Tests::StructTest.new( 123 ), <<EOY )
 --- !ruby/struct:Psych_Tests::StructTest
+c: 123
+EOY
+
+    end
+
+    def test_ruby_data
+        omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+        Object.remove_const :MyBookData if Object.const_defined?(:MyBookData)
+        # Ruby Data value objects
+        book_class = Data.define(:author, :title, :year, :isbn)
+        Object.const_set(:MyBookData, book_class)
+        assert_to_yaml(
+            [ book_class.new( "Yukihiro Matsumoto", "Ruby in a Nutshell", 2002, "0-596-00214-9" ),
+              book_class.new( [ 'Dave Thomas', 'Andy Hunt' ], "The Pickaxe", 2002,
+                book_class.new( "This should be the ISBN", "but I have more data here", 2002, "None" )
+              )
+            ], <<EOY
+- !ruby/data:MyBookData
+  author: Yukihiro Matsumoto
+  title: Ruby in a Nutshell
+  year: 2002
+  isbn: 0-596-00214-9
+- !ruby/data:MyBookData
+  author:
+    - Dave Thomas
+    - Andy Hunt
+  title: The Pickaxe
+  year: 2002
+  isbn: !ruby/data:MyBookData
+    author: This should be the ISBN
+    title: but I have more data here
+    year: 2002
+    isbn: None
+EOY
+        )
+
+        assert_to_yaml( Psych_Tests::DataTest.new( 123 ), <<EOY )
+--- !ruby/data:Psych_Tests::DataTest
 c: 123
 EOY
 

--- a/test/psych/visitors/test_yaml_tree.rb
+++ b/test/psych/visitors/test_yaml_tree.rb
@@ -73,6 +73,27 @@ module Psych
         assert_equal s.method, obj.method
       end
 
+      D = Data.define(:foo) unless RUBY_VERSION < "3.2"
+
+      def test_data
+        omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+        assert_cycle D.new('bar')
+      end
+
+      def test_data_anon
+        omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+        d = Data.define(:foo).new('bar')
+        obj =  Psych.unsafe_load(Psych.dump(d))
+        assert_equal d.foo, obj.foo
+      end
+
+      def test_data_override_method
+        omit "Data requires ruby >= 3.2" if RUBY_VERSION < "3.2"
+        d = Data.define(:method).new('override')
+        obj =  Psych.unsafe_load(Psych.dump(d))
+        assert_equal d.method, obj.method
+      end
+
       def test_exception
         ex = Exception.new 'foo'
         loaded = Psych.unsafe_load(Psych.dump(ex))


### PR DESCRIPTION
This adds basic encoding/decoding for ruby 3.2 `Data` objects, using `!ruby/data:ClassName` (a mapping of member names to member values) and `!ruby/data-with-ivars:ClassName` tags (a mapping with `members` and `ivars` mappings).  Like `Marshal`, this uses `rb_struct_initialize` to assign member values to new `Data` objects.

----

Originally (in the first commit), I updated `Visitor::ToRuby` to simply call `data.send(:initialize, **members)`.  But `#initialize` freezes the object, so we can't set instance variables afterwards.

The second commit sets instance variables before calling `#initialize`, which I think will lead to unhappy surprises for some users.  Unfortunately, `Data` doesn't give us any other mechanism for setting the members... except for the C API.

The third commit works around the above issue by copying how Marshal loads `Data` objects, delegating `ToRuby#init_struct(obj, members)` to `rb_struct_initialize`.  I think this is the least surprising behavior for users.  This also bypasses any user-defined `#initialize` method (which may be seen as a feature or a bug).