### PR TITLE
Eagerly require `date`

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'date'
+
 require_relative 'psych/versions'
 case RUBY_ENGINE
 when 'jruby'

--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -4,8 +4,6 @@ module Psych
   ###
   # Scan scalars for built in types
   class ScalarScanner
-    autoload :Date, "date"
-
     # Taken from http://yaml.org/type/timestamp.html
     TIME = /^-?\d{4}-\d{1,2}-\d{1,2}(?:[Tt]|\s+)\d{1,2}:\d\d:\d\d(?:\.\d*)?(?:\s*(?:Z|[-+]\d{1,2}:?(?:\d\d)?))?$/
 

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -79,7 +79,6 @@ module Psych
           class_loader.big_decimal._load o.value
         when "!ruby/object:DateTime"
           class_loader.date_time
-          require 'date' unless defined? DateTime
           t = @ss.parse_time(o.value)
           DateTime.civil(*t.to_a[0, 6].reverse, Rational(t.utc_offset, 86400)) +
             (t.subsec/86400)

--- a/psych.gemspec
+++ b/psych.gemspec
@@ -75,6 +75,8 @@ DESCRIPTION
     s.add_dependency 'stringio'
   end
 
+  s.add_dependency 'date'
+
   s.metadata['msys2_mingw_dependencies'] = 'libyaml'
   s.metadata['changelog_uri'] = s.homepage + '/releases'
 end

--- a/test/psych/helper.rb
+++ b/test/psych/helper.rb
@@ -2,7 +2,6 @@
 require 'test/unit'
 require 'stringio'
 require 'tempfile'
-require 'date'
 
 require 'psych'
 

--- a/test/psych/test_date_time.rb
+++ b/test/psych/test_date_time.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require_relative 'helper'
-require 'date'
 
 module Psych
   class TestDateTime < TestCase

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require_relative 'helper'
-require 'date'
 
 module Psych
   class TestScalarScanner < TestCase

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -50,6 +50,16 @@ module Psych
       assert_equal str, Psych.load(yaml)
     end
 
+    def test_single_quote_when_matching_date
+      pend "Failing on JRuby" if RUBY_PLATFORM =~ /java/
+
+      lib = File.expand_path("../../../lib", __FILE__)
+      assert_separately(["-I", lib, "-r", "psych"], __FILE__, __LINE__ + 1, <<~'RUBY')
+        yml = Psych.dump('2024-11-19')
+        assert_equal '2024-11-19', Psych.load(yml)
+      RUBY
+    end
+
     def test_plain_when_shorten_than_line_width_and_no_final_line_break
       str = "Lorem ipsum"
       yaml = Psych.dump str, line_width: 12


### PR DESCRIPTION
Fixes https://github.com/ruby/psych/issues/694. 

When picking up only the test changes (and not `require 'date'` explicitly anymore), such failures start to appear:
```
Error: test_spec_sequence_key_shortcut(Psych_Unit_Tests): NameError: uninitialized constant Psych_Unit_Tests::Date
/Users/thierry/workspace_personal/psych/test/psych/test_yaml.rb:299:in `test_spec_sequence_key_shortcut'
     296:     def test_spec_sequence_key_shortcut
     297:         # Shortcut sequence map
     298:         assert_parse_only(
  => 299:           { 'invoice' => 34843, 'date' => Date.new( 2001, 1, 23 ),
     300:             'bill-to' => 'Chris Dumars', 'product' =>
     301:             [ { 'item' => 'Super Hoop', 'quantity' => 1 },
     302:               { 'item' => 'Basketball', 'quantity' => 4 },
=======================================================================================================================
Finished in 0.390079 seconds.
-----------------------------------------------------------------------------------------------------------------------
609 tests, 1481 assertions, 0 failures, 21 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed
```

The `autoload :Date` statement gets moved to a more appropriate file (the one actually loading the constant), and moved to the top-level so it requires `::Date` and not try to require `Psych::ClassLoader::Date`

Performance-wise, reusing the benchmark from https://github.com/ruby/psych/commit/06db36fa3a849f229e2cbc7b495d142ff58a1f89#diff-6a459e056cadf37665f54005bd2dde09d9ba8e66c9807eb0dc67145f9b841771R7, it seems to further improve performance quite unsignificantly:

With those changes:
```
$ ruby /tmp/bench-yaml.rb
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [arm64-darwin23]
Warming up --------------------------------------
           100 dates   464.000 i/100ms
Calculating -------------------------------------
           100 dates      4.605k (± 2.3%) i/s  (217.18 μs/i) -     23.200k in   5.041382s
```

On current master:
```
$ ruby /tmp/bench-yaml.rb
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [arm64-darwin23]
Warming up --------------------------------------
           100 dates   439.000 i/100ms
Calculating -------------------------------------
           100 dates      4.515k (± 1.9%) i/s  (221.49 μs/i) -     22.828k in   5.058050s
```