### PR TITLE
Don't autolink Exception in psych module docs

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -86,7 +86,7 @@ require_relative 'psych/class_loader'
 #   Psych.safe_load_file("data.yml", permitted_classes: [Date])
 #   Psych.load_file("trusted_database.yml")
 #
-# ==== Exception handling
+# ==== \Exception handling
 #
 #   begin
 #     # The second argument changes only the exception contents
@@ -150,7 +150,7 @@ require_relative 'psych/class_loader'
 #   # Returns Psych::Nodes::Document
 #   Psych.parse_file('database.yml')
 #
-# ==== Exception handling
+# ==== \Exception handling
 #
 #   begin
 #     # The second argument changes only the exception contents


### PR DESCRIPTION
https://docs.ruby-lang.org/en/master/Psych.html#module-Psych-label-Exception+handling

![Screenshot from 2024-12-05 15-05-46](https://github.com/user-attachments/assets/2669123c-592e-47e5-831b-3bef40d2d833)
