### PR TITLE
Avoid calls to `require` in hotspots

### DIFF
--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -55,7 +55,8 @@ module Psych
       #
       # See also Psych::Visitors::Emitter
       def yaml io = nil, options = {}
-        require "stringio"
+        require "stringio" unless defined?(StringIO)
+
         real_io = io || StringIO.new(''.encode('utf-8'))
 
         Visitors::Emitter.new(real_io, options).accept self


### PR DESCRIPTION
Followup: https://github.com/ruby/psych/pull/686

This single call shows up as 4% of some controller actions in the lobsters benchmark.

Profile: https://share.firefox.dev/3EqKnhS

