### PR TITLE
Fix loading/parsing regular expressions with forward slashes

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -96,11 +96,11 @@ module Psych
           Float(@ss.tokenize(o.value))
         when "!ruby/regexp"
           klass = class_loader.regexp
-          o.value =~ /^\/(.*)\/([mixn]*)$/m
-          source  = $1
+          matches = /^\/(?<string>.*)\/(?<options>[mixn]*)$/m.match(o.value)
+          source  = matches[:string].gsub('\/', '/')
           options = 0
           lang    = nil
-          $2&.each_char do |option|
+          matches[:options].each_char do |option|
             case option
             when 'x' then options |= Regexp::EXTENDED
             when 'i' then options |= Regexp::IGNORECASE

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -35,6 +35,10 @@ class Psych_Unit_Tests < Psych::TestCase
         assert_cycle(Regexp.new("foo\nbar"))
     end
 
+    def test_regexp_with_slash
+      assert_cycle(Regexp.new('/'))
+    end
+
     # [ruby-core:34969]
     def test_regexp_with_n
         assert_cycle(Regexp.new('',Regexp::NOENCODING))


### PR DESCRIPTION
This fixes the issue where regular expression would come back slightly different after going through a YAML load/dump cycle. Because we're used to having to escape forward slashes in regular expression literals (because the literal is delimited by slashes), but the deserializer takes the literal output from `Regexp#inspect` and feeds it as a string into `Regexp.new`, which expects a string, not a Regexp literal, cycling did not properly work before this commit.

I've also changed the code to be a bit more readable, I hope this doesn't affect performance.

Fixes #523 