### PR TITLE
Adding safe_load_stream: a ( nearly ) equivalent to load_stream, but safe

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -672,7 +672,7 @@ module Psych
     documents = parse_stream(yaml, filename: filename).children.map do |child|
       stream = Psych::Nodes::Stream.new
       stream.children << child
-      safe_load stream.to_yaml, permitted_classes: permitted_classes, aliases: aliases
+      safe_load(stream.to_yaml, permitted_classes: permitted_classes, aliases: aliases)
     end
 
     if block_given?

--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -655,6 +655,26 @@ module Psych
   end
 
   ###
+  # Load multiple documents given in +yaml+. Returns the parsed documents
+  # as a list.
+  #
+  # Example:
+  #
+  #   Psych.safe_load_stream("--- foo\n...\n--- bar\n...") # => ['foo', 'bar']
+  #
+  #   list = []
+  #   Psych.safe_load_stream("--- foo\n...\n--- bar\n...") do |ruby|
+  #     list << ruby
+  #   end
+  #   list # => ['foo', 'bar']
+  #
+  def self.safe_load_stream yaml, filename: nil, permitted_classes: [], aliases: false
+    parse_stream(yaml, filename: filename).children.map do |child|
+      safe_load(child.to_yaml, permitted_classes, aliases: aliases)
+    end
+  end
+
+  ###
   # Load the document contained in +filename+.  Returns the yaml contained in
   # +filename+ as a Ruby object, or if the file is empty, it returns
   # the specified +fallback+ return value, which defaults to +false+.

--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -669,8 +669,17 @@ module Psych
   #   list # => ['foo', 'bar']
   #
   def self.safe_load_stream yaml, filename: nil, permitted_classes: [], aliases: false
-    parse_stream(yaml, filename: filename).children.map do |child|
-      safe_load(child.to_yaml, permitted_classes, aliases: aliases)
+    documents = parse_stream(yaml, filename: filename).children.map do |child|
+      stream = Psych::Nodes::Stream.new
+      stream.children << child
+      safe_load stream.to_yaml, permitted_classes: permitted_classes, aliases: aliases
+    end
+
+    if block_given?
+      documents.each { |doc| yield doc }
+      nil
+    else
+      documents
     end
   end
 

--- a/test/psych/test_exception.rb
+++ b/test/psych/test_exception.rb
@@ -82,6 +82,19 @@ module Psych
       assert_equal 'omg!', ex.file
     end
 
+    def test_safe_load_stream_takes_file
+      ex = assert_raise(Psych::SyntaxError) do
+        Psych.safe_load_stream '--- `'
+      end
+      assert_nil ex.file
+      assert_match '(<unknown>)', ex.message
+
+      ex = assert_raise(Psych::SyntaxError) do
+        Psych.safe_load_stream '--- `', filename: 'omg!'
+      end
+      assert_equal 'omg!', ex.file
+    end
+
     def test_parse_file_exception
       Tempfile.create(['parsefile', 'yml']) {|t|
         t.binmode

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -89,6 +89,7 @@ class TestPsych < Psych::TestCase
     things = [22, "foo \n", {}]
     stream = Psych.dump_stream(*things)
     assert_equal things, Psych.load_stream(stream)
+    assert_equal things, Psych.safe_load_stream(stream)
   end
 
   def test_dump_file
@@ -119,6 +120,8 @@ class TestPsych < Psych::TestCase
   def test_load_stream
     docs = Psych.load_stream("--- foo\n...\n--- bar\n...")
     assert_equal %w{ foo bar }, docs
+    safe_docs = Psych.safe_load_stream("--- foo\n...\n--- bar\n...")
+    assert_equal %w{ foo bar }, safe_docs
   end
 
   def test_load_stream_freeze
@@ -138,8 +141,16 @@ class TestPsych < Psych::TestCase
     assert_equal [], Psych.load_stream("")
   end
 
+  def test_safe_load_stream_default_fallback
+    assert_equal [], Psych.safe_load_stream("")
+  end
+
   def test_load_stream_raises_on_bad_input
     assert_raise(Psych::SyntaxError) { Psych.load_stream("--- `") }
+  end
+
+  def test_safe_load_stream_raises_on_bad_input
+    assert_raise(Psych::SyntaxError) { Psych.safe_load_stream("--- `") }
   end
 
   def test_parse_stream

--- a/test/psych/test_stream.rb
+++ b/test/psych/test_stream.rb
@@ -54,6 +54,14 @@ module Psych
       assert_equal %w{ foo bar }, list
     end
 
+    def test_safe_load_stream_yields_documents
+      list = []
+      Psych.safe_load_stream("--- foo\n...\n--- bar") do |ruby|
+        list << ruby
+      end
+      assert_equal %w{ foo bar }, list
+    end
+
     def test_load_stream_break
       list = []
       Psych.load_stream("--- foo\n...\n--- `") do |ruby|

--- a/test/psych/test_yaml_special_cases.rb
+++ b/test/psych/test_yaml_special_cases.rb
@@ -15,6 +15,7 @@ module Psych
       s = ""
       assert_equal false, Psych.unsafe_load(s)
       assert_equal [], Psych.load_stream(s)
+      assert_equal [], Psych.safe_load_stream(s)
       assert_equal false, Psych.parse(s)
       assert_equal [], Psych.parse_stream(s).transform
       assert_nil   Psych.safe_load(s)
@@ -24,6 +25,7 @@ module Psych
       s = "false"
       assert_equal false, Psych.load(s)
       assert_equal [false], Psych.load_stream(s)
+      assert_equal [false], Psych.safe_load_stream(s)
       assert_equal false, Psych.parse(s).transform
       assert_equal [false], Psych.parse_stream(s).transform
       assert_equal false, Psych.safe_load(s)
@@ -33,6 +35,7 @@ module Psych
       s = "n"
       assert_equal "n", Psych.load(s)
       assert_equal ["n"], Psych.load_stream(s)
+      assert_equal ["n"], Psych.safe_load_stream(s)
       assert_equal "n", Psych.parse(s).transform
       assert_equal ["n"], Psych.parse_stream(s).transform
       assert_equal "n", Psych.safe_load(s)
@@ -42,6 +45,7 @@ module Psych
       s = "off"
       assert_equal false, Psych.load(s)
       assert_equal [false], Psych.load_stream(s)
+      assert_equal [false], Psych.safe_load_stream(s)
       assert_equal false, Psych.parse(s).transform
       assert_equal [false], Psych.parse_stream(s).transform
       assert_equal false, Psych.safe_load(s)
@@ -51,6 +55,7 @@ module Psych
       s = "-.inf"
       assert_equal(-Float::INFINITY, Psych.load(s))
       assert_equal([-Float::INFINITY], Psych.load_stream(s))
+      assert_equal([-Float::INFINITY], Psych.safe_load_stream(s))
       assert_equal(-Float::INFINITY, Psych.parse(s).transform)
       assert_equal([-Float::INFINITY], Psych.parse_stream(s).transform)
       assert_equal(-Float::INFINITY, Psych.safe_load(s))
@@ -60,6 +65,7 @@ module Psych
       s = ".NaN"
       assert Psych.load(s).nan?
       assert Psych.load_stream(s).first.nan?
+      assert Psych.safe_load_stream(s).first.nan?
       assert Psych.parse(s).transform.nan?
       assert Psych.parse_stream(s).transform.first.nan?
       assert Psych.safe_load(s).nan?
@@ -69,6 +75,7 @@ module Psych
       s = "0xC"
       assert_equal 12, Psych.load(s)
       assert_equal [12], Psych.load_stream(s)
+      assert_equal [12], Psych.safe_load_stream(s)
       assert_equal 12, Psych.parse(s).transform
       assert_equal [12], Psych.parse_stream(s).transform
       assert_equal 12, Psych.safe_load(s)
@@ -78,6 +85,7 @@ module Psych
       s = "<<"
       assert_equal "<<", Psych.load(s)
       assert_equal ["<<"], Psych.load_stream(s)
+      assert_equal ["<<"], Psych.safe_load_stream(s)
       assert_equal "<<", Psych.parse(s).transform
       assert_equal ["<<"], Psych.parse_stream(s).transform
       assert_equal "<<", Psych.safe_load(s)
@@ -87,6 +95,7 @@ module Psych
       s = "<<: {}"
       assert_equal({}, Psych.load(s))
       assert_equal [{}], Psych.load_stream(s)
+      assert_equal [{}], Psych.safe_load_stream(s)
       assert_equal({}, Psych.parse(s).transform)
       assert_equal [{}], Psych.parse_stream(s).transform
       assert_equal({}, Psych.safe_load(s))
@@ -96,6 +105,7 @@ module Psych
       s = "- 1000\n- +1000\n- 1_000"
       assert_equal [1000, 1000, 1000], Psych.load(s)
       assert_equal [[1000, 1000, 1000]], Psych.load_stream(s)
+      assert_equal [[1000, 1000, 1000]], Psych.safe_load_stream(s)
       assert_equal [1000, 1000, 1000], Psych.parse(s).transform
       assert_equal [[1000, 1000, 1000]], Psych.parse_stream(s).transform
       assert_equal [1000, 1000, 1000], Psych.safe_load(s)
@@ -105,6 +115,7 @@ module Psych
       s = "[8, 08, 0o10, 010]"
       assert_equal [8, "08", "0o10", 8], Psych.load(s)
       assert_equal [[8, "08", "0o10", 8]], Psych.load_stream(s)
+      assert_equal [[8, "08", "0o10", 8]], Psych.safe_load_stream(s)
       assert_equal [8, "08", "0o10", 8], Psych.parse(s).transform
       assert_equal [[8, "08", "0o10", 8]], Psych.parse_stream(s).transform
       assert_equal [8, "08", "0o10", 8], Psych.safe_load(s)
@@ -114,6 +125,7 @@ module Psych
       s = "null"
       assert_nil   Psych.load(s)
       assert_equal [nil], Psych.load_stream(s)
+      assert_equal [nil], Psych.safe_load_stream(s)
       assert_nil   Psych.parse(s).transform
       assert_equal [nil], Psych.parse_stream(s).transform
       assert_nil   Psych.safe_load(s)


### PR DESCRIPTION
Hi !
It seems that some functions have an equivalent `safe_` versions, when user controlled yaml files are handled. Looking at CVEs like [CVE-2024-42363][1], and its [fix][2], I implemented a minimal `safe_load_stream` that handles most relevant use cases.

From a security perspective, it seems that users might benefit from the existence of such a safe variant.
Would be happy to get feedback, add more tests and the like. Thanks !

[1]: https://nvd.nist.gov/vuln/detail/CVE-2024-42363
[2]: https://github.com/zendesk/samson/pull/4071/files