### PR TITLE
Fix dumping `StringIO` (and potentially others) on Ruby <= 2.7

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -198,7 +198,7 @@ module Psych
 
           @emitter.end_mapping
         end
-      end
+      end unless RUBY_VERSION < "3.2"
 
       def visit_Struct o
         tag = ['!ruby/struct', o.class.name].compact.join(':')

--- a/test/psych/test_stringio.rb
+++ b/test/psych/test_stringio.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+module Psych
+  class TestStringIO < TestCase
+    # The superclass of StringIO before Ruby 3.0 was `Data`,
+    # which can interfere with the Ruby 3.2+ `Data` dumping.
+    def test_stringio
+      assert_nothing_raised do
+        Psych.dump(StringIO.new("foo"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
In Ruby < 3.0, the superclass of StringIO was actually already `Data`, but it doesn't have the expected shape. So, on these earlier versions it errors:
> NoMethodError: undefined method `members' for #<StringIO:0x00005641dd5f2880>
>    vendor/bundle/ruby/2.6.0/gems/psych-5.2.5/lib/psych/visitors/yaml_tree.rb:170:in `visit_Data'

This test doesn't fail on 2.7, presumably because it can pull in a newer `stringio` version.

Some context: https://bugs.ruby-lang.org/issues/3072

Here's a test failure before the fix: https://github.com/Earlopain/psych/actions/runs/14976611657/job/42070451324