### PR TITLE
Use the latest stable version for trusted publisher

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.3", "jruby"]
+        ruby: ["ruby", "jruby"]
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
`3.3` will be EOL at two years later. We should point the latest stable version for the trusted publisher.