### PR TITLE
CI: Skip ppc64le/s390x cases in forked repositories.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,8 @@ jobs:
         run: rake install
         if: ${{ steps.test.outcome == 'success' }}
 
-  test2:
+  test-ibm:
+    if: github.repository == 'ruby/psych'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
/cc @hsbt

This PR is a follow up of the https://github.com/ruby/psych/pull/738.

The GitHub Actions ppc64le/s390x runners don't work on forked repositories. These only work on the registered repositories.

https://github.com/junaruga/ruby-psych/actions/runs/16468016918/job/46550090501
