### PR TITLE
Add option to disable symbol parsing for ScalarParser

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -269,10 +269,10 @@ module Psych
   # YAML documents that are supplied via user input.  Instead, please use the
   # load method or the safe_load method.
   #
-  def self.unsafe_load yaml, filename: nil, fallback: false, symbolize_names: false, freeze: false, strict_integer: false
+  def self.unsafe_load yaml, filename: nil, fallback: false, symbolize_names: false, freeze: false, strict_integer: false, parse_symbols: true
     result = parse(yaml, filename: filename)
     return fallback unless result
-    result.to_ruby(symbolize_names: symbolize_names, freeze: freeze, strict_integer: strict_integer)
+    result.to_ruby(symbolize_names: symbolize_names, freeze: freeze, strict_integer: strict_integer, parse_symbols: parse_symbols)
   end
 
   ###
@@ -320,13 +320,13 @@ module Psych
   #   Psych.safe_load("---\n foo: bar")                         # => {"foo"=>"bar"}
   #   Psych.safe_load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
   #
-  def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
+  def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false, parse_symbols: true
     result = parse(yaml, filename: filename)
     return fallback unless result
 
     class_loader = ClassLoader::Restricted.new(permitted_classes.map(&:to_s),
                                                permitted_symbols.map(&:to_s))
-    scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer
+    scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer, parse_symbols: parse_symbols
     visitor = if aliases
                 Visitors::ToRuby.new scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze
               else
@@ -366,7 +366,7 @@ module Psych
   # Raises a TypeError when `yaml` parameter is NilClass.  This method is
   # similar to `safe_load` except that `Symbol` objects are allowed by default.
   #
-  def self.load yaml, permitted_classes: [Symbol], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false
+  def self.load yaml, permitted_classes: [Symbol], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false, strict_integer: false, parse_symbols: true
     safe_load yaml, permitted_classes: permitted_classes,
                     permitted_symbols: permitted_symbols,
                     aliases: aliases,
@@ -374,7 +374,8 @@ module Psych
                     fallback: fallback,
                     symbolize_names: symbolize_names,
                     freeze: freeze,
-                    strict_integer: strict_integer
+                    strict_integer: strict_integer,
+                    parse_symbols: parse_symbols
   end
 
   ###

--- a/lib/psych/nodes/node.rb
+++ b/lib/psych/nodes/node.rb
@@ -45,8 +45,8 @@ module Psych
       # Convert this node to Ruby.
       #
       # See also Psych::Visitors::ToRuby
-      def to_ruby(symbolize_names: false, freeze: false, strict_integer: false)
-        Visitors::ToRuby.create(symbolize_names: symbolize_names, freeze: freeze, strict_integer: strict_integer).accept(self)
+      def to_ruby(symbolize_names: false, freeze: false, strict_integer: false, parse_symbols: true)
+        Visitors::ToRuby.create(symbolize_names: symbolize_names, freeze: freeze, strict_integer: strict_integer, parse_symbols: true).accept(self)
       end
       alias :transform :to_ruby
 

--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -27,10 +27,11 @@ module Psych
     attr_reader :class_loader
 
     # Create a new scanner
-    def initialize class_loader, strict_integer: false
+    def initialize class_loader, strict_integer: false, parse_symbols: true
       @symbol_cache = {}
       @class_loader = class_loader
       @strict_integer = strict_integer
+      @parse_symbols = parse_symbols
     end
 
     # Tokenize +string+ returning the Ruby object
@@ -72,7 +73,7 @@ module Psych
         -Float::INFINITY
       elsif string.match?(/^\.nan$/i)
         Float::NAN
-      elsif string.match?(/^:./)
+      elsif @parse_symbols && string.match?(/^:./)
         if string =~ /^:(["'])(.*)\1/
           @symbol_cache[string] = class_loader.symbolize($2.sub(/^:/, ''))
         else

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -12,9 +12,9 @@ module Psych
     ###
     # This class walks a YAML AST, converting each node to Ruby
     class ToRuby < Psych::Visitors::Visitor
-      def self.create(symbolize_names: false, freeze: false, strict_integer: false)
+      def self.create(symbolize_names: false, freeze: false, strict_integer: false, parse_symbols: true)
         class_loader = ClassLoader.new
-        scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer
+        scanner      = ScalarScanner.new class_loader, strict_integer: strict_integer, parse_symbols: parse_symbols
         new(scanner, class_loader, symbolize_names: symbolize_names, freeze: freeze)
       end
 

--- a/test/psych/test_scalar_scanner.rb
+++ b/test/psych/test_scalar_scanner.rb
@@ -138,6 +138,11 @@ module Psych
       assert_equal '-0b___', scanner.tokenize('-0b___')
     end
 
+    def test_scan_without_parse_symbols
+      scanner = Psych::ScalarScanner.new ClassLoader.new, parse_symbols: false
+      assert_equal ':foo', scanner.tokenize(':foo')
+    end
+
     def test_scan_int_commas_and_underscores
       # NB: This test is to ensure backward compatibility with prior Psych versions,
       # not to test against any actual YAML specification.


### PR DESCRIPTION
This PR adds an option to `ScalarParser` to disable the parsing of values containing a leading colon as symbols. This is unexpected behavior when compared with other YAML parsers and when compared with the YAML specification, as symbols are not a concept defined by YAML. I do not expect that we can change the default here as that would break backwards compatibility, so this PR maintains current behavior by leaving the default as `parse_symbols: true`, but exposes a way that users can modify the behavior in order to match what is expected based on the YAML specification.

The option is expected to the `load()` family of methods at the top level as well as to the `ToRuby` visitor and the associated node `to_ruby()` method. In all instances, the default value of the new `parse_symbols` parameter is `true` in order to maintain backwards-compatible behavior. Passing a value of `false` for this parameter will result in values with leading colons being treated as regular strings.