### PR TITLE
Remove warning by not calling find_library after pkg_config

### DIFF
--- a/ext/psych/extconf.rb
+++ b/ext/psych/extconf.rb
@@ -36,8 +36,11 @@ if yaml_source
   libyaml = "libyaml.#$LIBEXT"
   $cleanfiles << libyaml
   $LOCAL_LIBS.prepend("$(LIBYAML) ")
-else # default to pre-installed libyaml
-  pkg_config('yaml-0.1')
+
+  # default to pre-installed libyaml
+elsif pkg_config('yaml-0.1')
+  # found with pkg-config
+else
   dir_config('libyaml')
   find_header('yaml.h') or abort "yaml.h not found"
   find_library('yaml', 'yaml_get_version') or abort "libyaml not found"


### PR DESCRIPTION
If `pkg_config` returns a truthy value, it found the library and added it to the global values for the Makefile.

Calling `find_library` after a successful `pkg_config` causes -lyaml to appear twice in the LIBS variable in the resulting Makefile, and causes ld on macOS to emit a warning:

    $ bundle exec rake compile 2>&1 | grep warning
    ld: warning: ignoring duplicate libraries: '-lyaml'