### PR TITLE
Fix error when loading a string with tab-separated datetime

### DIFF
--- a/lib/psych/scalar_scanner.rb
+++ b/lib/psych/scalar_scanner.rb
@@ -115,7 +115,7 @@ module Psych
     def parse_time string
       klass = class_loader.load 'Time'
 
-      date, time = *(string.split(/[ tT]/, 2))
+      date, time = *(string.split(/[Tt]|\s+/, 2))
       (yy, m, dd) = date.match(/^(-?\d{4})-(\d{1,2})-(\d{1,2})/).captures.map { |x| x.to_i }
       md = time.match(/(\d+:\d+:\d+)(?:\.(\d*))?\s*(Z|[-+]\d+(:\d\d)?)?/)
 

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -60,6 +60,11 @@ module Psych
       RUBY
     end
 
+    def test_datetime_string_with_tab_separator
+      str = "2023-12-31\t12:00:00"
+      assert_cycle str
+    end
+
     def test_plain_when_shorten_than_line_width_and_no_final_line_break
       str = "Lorem ipsum"
       yaml = Psych.dump str, line_width: 12

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -65,6 +65,12 @@ module Psych
       assert_cycle str
     end
 
+    def test_datetime_string_with_whitespace_separators
+      ["\v", "\r", "\f", " \t", "\t "].each do |sep|
+        assert_cycle "2023-12-31#{sep}12:00:00"
+      end
+    end
+
     def test_plain_when_shorten_than_line_width_and_no_final_line_break
       str = "Lorem ipsum"
       yaml = Psych.dump str, line_width: 12


### PR DESCRIPTION
Issue: https://github.com/ruby/psych/issues/691

Error w/o fix:
<img width="1016" height="429" alt="Screenshot 2025-11-24 at 14 55 00" src="https://github.com/user-attachments/assets/7fc0423b-f5ee-4a10-8487-a61ea50338f3" />

date/time splitter is now equal to the one in [TIME](https://github.com/ruby/psych/blob/master/lib/psych/scalar_scanner.rb#L8) regexp.
