### PR TITLE
Revert "Update SnakeYAML-Engine to 3.0.1"

### DIFF
--- a/lib/psych/versions.rb
+++ b/lib/psych/versions.rb
@@ -5,6 +5,6 @@ module Psych
   VERSION = '5.3.1'
 
   if RUBY_ENGINE == 'jruby'
-    DEFAULT_SNAKEYAML_VERSION = '3.0.1'.freeze
+    DEFAULT_SNAKEYAML_VERSION = '2.10'.freeze
   end
 end


### PR DESCRIPTION
Reverts ruby/psych#781

I did not realize that SnakeYAML 3+ has a minimum Java requirement of 11, which would break Psych for JRuby 9.4 users that are still on Java 8.

Rather than try to force that issue, and because this wasn't *really* a security issue to begin with, I'm reverting the change for now.

We'll look at bumping Psych up at some point in the future after JRuby 9.4 has been EOL for a while.

Just to repeat: there's really no security issue here, as the dependency in question was only used at test time by SnakeYAML 2.x.