### PR TITLE
Clamp `io_reader` copy to the buffer libyaml provides

### DIFF
--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -33,8 +33,15 @@ static int io_reader(void * data, unsigned char *buf, size_t size, size_t *read)
 
     if(! NIL_P(string)) {
         void * str = (void *)StringValuePtr(string);
-        *read = (size_t)RSTRING_LEN(string);
-        memcpy(buf, str, *read);
+        size_t len = (size_t)RSTRING_LEN(string);
+
+        /* IO#read(size) is documented to return at most `size` bytes, but a
+         * misbehaving IO-like object may return more. Clamp the copy to the
+         * buffer libyaml gave us to avoid writing past its end. */
+        if(len > size) len = size;
+
+        *read = len;
+        memcpy(buf, str, len);
     }
 
     return 1;

--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -32,13 +32,17 @@ static int io_reader(void * data, unsigned char *buf, size_t size, size_t *read)
     *read = 0;
 
     if(! NIL_P(string)) {
-        void * str = (void *)StringValuePtr(string);
+        char * str = StringValuePtr(string);
         size_t len = (size_t)RSTRING_LEN(string);
 
         /* IO#read(size) is documented to return at most `size` bytes, but a
          * misbehaving IO-like object may return more. Clamp the copy to the
-         * buffer libyaml gave us to avoid writing past its end. */
-        if(len > size) len = size;
+         * buffer libyaml gave us to avoid writing past its end, rounding down
+         * to a character boundary so a multibyte character is never split. */
+        if(len > size) {
+            rb_encoding * enc = rb_enc_get(string);
+            len = (size_t)(rb_enc_left_char_head(str, str + size, str + len, enc) - str);
+        }
 
         *read = len;
         memcpy(buf, str, len);

--- a/test/psych/test_parser.rb
+++ b/test/psych/test_parser.rb
@@ -221,6 +221,25 @@ module Psych
       assert_called :end_stream
     end
 
+    def test_parse_io_returns_more_bytes_than_requested_multibyte
+      # The over-read is rounded down to a character boundary so a multibyte
+      # character is never split when the copy is clamped.
+      io = Object.new
+      def io.external_encoding; Encoding::UTF_8 end
+      def io.read len
+        return nil if @done
+        @done = true
+        "--- a\n#" + ("あ" * (len + (1 << 20)))
+      end
+
+      begin
+        @parser.parse io
+      rescue IOError
+        return
+      end
+      assert_called :scalar
+    end
+
     def test_syntax_error
       assert_raise(Psych::SyntaxError) do
         @parser.parse("---\n\"foo\"\n\"bar\"\n")

--- a/test/psych/test_parser.rb
+++ b/test/psych/test_parser.rb
@@ -198,6 +198,29 @@ module Psych
       assert_called :end_stream
     end
 
+    def test_parse_io_returns_more_bytes_than_requested
+      # An IO-like source whose #read returns more bytes than the size it was
+      # asked for must not overflow libyaml's read buffer.
+      io = Object.new
+      def io.external_encoding; Encoding::UTF_8 end
+      def io.read len
+        return nil if @done
+        @done = true
+        "--- a\n" + ("#" * (len + (1 << 20)))
+      end
+
+      # CRuby clamps the over-read and parses; JRuby's parser rejects the
+      # over-reading IO with an IOError. Either way there is no overflow.
+      begin
+        @parser.parse io
+      rescue IOError
+        return
+      end
+      assert_called :start_stream
+      assert_called :scalar
+      assert_called :end_stream
+    end
+
     def test_syntax_error
       assert_raise(Psych::SyntaxError) do
         @parser.parse("---\n\"foo\"\n\"bar\"\n")


### PR DESCRIPTION
`io_reader` registers as libyaml's read handler, calls `IO#read(size)`, and copies the returned string into a fixed-capacity buffer. It copied the full returned length instead of the requested size, so an IO whose #read returns more bytes than asked for overruns the buffer.

This is a heap out-of-bounds write reachable from `Psych.load` and similar methods. Standard readers like `StringIO` honour the size limit, and only a custom IO that over-returns hits
this. 

This change clamps the copy to the requested size.