### PR TITLE
Harden safe load

### DIFF
--- a/lib/psych/class_loader.rb
+++ b/lib/psych/class_loader.rb
@@ -9,6 +9,7 @@ module Psych
     DATA        = 'Data' unless RUBY_VERSION < "3.2"
     DATE        = 'Date'
     DATE_TIME   = 'DateTime'
+    ENCODING    = 'Encoding'
     EXCEPTION   = 'Exception'
     OBJECT      = 'Object'
     PSYCH_OMAP  = 'Psych::Omap'

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -72,7 +72,7 @@ module Psych
         when '!binary', 'tag:yaml.org,2002:binary'
           o.value.unpack('m').first
         when /^!(?:str|ruby\/string)(?::(.*))?$/, 'tag:yaml.org,2002:str'
-          klass = resolve_class($1)
+          klass = resolve_subclass($1, String)
           if klass
             klass.allocate.replace o.value
           else
@@ -157,7 +157,7 @@ module Psych
           }
           map
         when /^!(?:seq|ruby\/array):(.*)$/
-          klass = resolve_class($1)
+          klass = resolve_subclass($1, Array)
           list  = register(o, klass.allocate)
           o.children.each { |c| list.push accept c }
           list
@@ -247,7 +247,7 @@ module Psych
           end
 
         when /^!(?:str|ruby\/string)(?::(.*))?$/, 'tag:yaml.org,2002:str'
-          klass   = resolve_class($1)
+          klass   = resolve_subclass($1, String)
           members = {}
           string  = nil
 
@@ -268,7 +268,7 @@ module Psych
           end
           init_with(string, members.map { |k,v| [k.to_s.sub(/^@/, ''),v] }, o)
         when /^!ruby\/array:(.*)$/
-          klass = resolve_class($1)
+          klass = resolve_subclass($1, Array)
           list  = register(o, klass.allocate)
 
           members = Hash[o.children.map { |c| accept c }.each_slice(2).to_a]

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -302,7 +302,7 @@ module Psych
           set
 
         when /^!ruby\/hash-with-ivars(?::(.*))?$/
-          hash = $1 ? resolve_class($1).allocate : {}
+          hash = $1 ? resolve_subclass($1, Hash).allocate : {}
           register o, hash
           o.children.each_slice(2) do |key, value|
             case key.value
@@ -317,7 +317,7 @@ module Psych
           hash
 
         when /^!map:(.*)$/, /^!ruby\/hash:(.*)$/
-          revive_hash register(o, resolve_class($1).allocate), o
+          revive_hash register(o, resolve_subclass($1, Hash).allocate), o
 
         when '!omap', 'tag:yaml.org,2002:omap'
           map = register(o, class_loader.psych_omap.new)
@@ -468,6 +468,19 @@ module Psych
       # Convert +klassname+ to a Class
       def resolve_class klassname
         class_loader.load klassname
+      end
+
+      # Resolve +klassname+ and ensure it is +parent+ or one of its
+      # subclasses. Tags such as !ruby/hash-with-ivars are only ever emitted
+      # for subclasses of a specific core class; without this check a crafted
+      # document could name an unrelated (but permitted) class and have its
+      # state populated directly, bypassing the class's own init_with.
+      def resolve_subclass klassname, parent
+        klass = resolve_class(klassname)
+        if klass && !(klass <= parent)
+          raise ArgumentError, "Invalid tag: expected a subclass of #{parent}, got #{klass}"
+        end
+        klass
       end
     end
 

--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -87,6 +87,7 @@ module Psych
           DateTime.civil(*t.to_a[0, 6].reverse, Rational(t.utc_offset, 86400)) +
             (t.subsec/86400)
         when '!ruby/encoding'
+          class_loader.encoding
           ::Encoding.find o.value
         when "!ruby/object:Complex"
           class_loader.complex

--- a/test/psych/test_array.rb
+++ b/test/psych/test_array.rb
@@ -52,6 +52,18 @@ module Psych
       assert_equal X, x.class
     end
 
+    class NotAnArray
+    end
+
+    def test_seq_tag_rejects_non_array_class
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load "--- !seq:#{NotAnArray} []\n"
+      end
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load "--- !ruby/array:#{NotAnArray} []\n"
+      end
+    end
+
     def test_self_referential
       @list << @list
       assert_cycle(@list)

--- a/test/psych/test_hash.rb
+++ b/test/psych/test_hash.rb
@@ -92,6 +92,31 @@ module Psych
       assert_equal X, x.class
     end
 
+    class NotAHash
+      def init_with(coder)
+        @string = coder.map["string"].to_s
+      end
+    end
+
+    def test_hash_with_ivars_rejects_non_hash_class
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load <<~eoyml
+          --- !ruby/hash-with-ivars:#{NotAHash}
+          ivars:
+            '@string': ["a surprise array!"]
+        eoyml
+      end
+    end
+
+    def test_hash_tag_rejects_non_hash_class
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load "--- !ruby/hash:#{NotAHash} {}\n"
+      end
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load "--- !map:#{NotAHash} {}\n"
+      end
+    end
+
     def test_self_referential
       @hash['self'] = @hash
       assert_cycle(@hash)

--- a/test/psych/test_safe_load.rb
+++ b/test/psych/test_safe_load.rb
@@ -74,6 +74,19 @@ module Psych
       assert_equal :foo, Psych.safe_load('--- !ruby/symbol foo', permitted_classes: [Symbol])
     end
 
+    def test_encoding
+      yaml = "--- !ruby/encoding UTF-8\n"
+      assert_raise(Psych::DisallowedClass) do
+        Psych.safe_load yaml
+      end
+      assert_raise(Psych::DisallowedClass) do
+        Psych.safe_load yaml, permitted_classes: []
+      end
+
+      assert_equal Encoding::UTF_8, Psych.safe_load(yaml, permitted_classes: [Encoding])
+      assert_equal Encoding::UTF_8, Psych.safe_load(yaml, permitted_classes: %w{ Encoding })
+    end
+
     def test_foo
       assert_raise(Psych::DisallowedClass) do
         Psych.safe_load '--- !ruby/object:Foo {}', permitted_classes: [Foo]

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -182,6 +182,18 @@ string: &70121654388580 !ruby/string
       assert_equal 1, y.val
     end
 
+    class NotAString
+    end
+
+    def test_string_tag_rejects_non_string_class
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load "--- !ruby/string:#{NotAString} foo\n"
+      end
+      assert_raise(ArgumentError) do
+        Psych.unsafe_load "--- !ruby/string:#{NotAString}\nstr: foo\n"
+      end
+    end
+
     def test_string_with_base_60
       yaml = Psych.dump '01:03:05'
       assert_match "'01:03:05'", yaml


### PR DESCRIPTION
- `!ruby/encoding` now resolves through the class loader, so `permitted_classes` is honored just like `!ruby/object:Encoding`.
- `!ruby/hash-with-ivars`, `!ruby/hash`, `!map` now require a Hash subclass, preventing `init_with` bypass via direct ivar injection.
- `!ruby/array`, `!seq`, `!ruby/string` now require an Array/String subclass for the same reason.