### PR TITLE
Strip a leading byte order mark before parsing

### DIFF
--- a/lib/psych/parser.rb
+++ b/lib/psych/parser.rb
@@ -81,7 +81,8 @@ module Psych
     def strip_bom yaml
       if String === yaml
         bom = BOM[yaml.encoding]
-        return yaml[1..-1] if bom && yaml.start_with?(bom)
+        # delete_prefix copies even when there is no prefix, so keep the guard.
+        return yaml.delete_prefix(bom) if bom && yaml.start_with?(bom)
       elsif yaml.respond_to?(:read) && yaml.respond_to?(:external_encoding) &&
             yaml.respond_to?(:pos) && yaml.respond_to?(:seek)
         bom = BOM[yaml.external_encoding]

--- a/lib/psych/parser.rb
+++ b/lib/psych/parser.rb
@@ -68,6 +68,8 @@ module Psych
       Encoding::UTF_8 => "\u{FEFF}".freeze,
       Encoding::UTF_16LE => "\u{FEFF}".encode(Encoding::UTF_16LE).freeze,
       Encoding::UTF_16BE => "\u{FEFF}".encode(Encoding::UTF_16BE).freeze,
+      Encoding::UTF_32LE => "\u{FEFF}".encode(Encoding::UTF_32LE).freeze,
+      Encoding::UTF_32BE => "\u{FEFF}".encode(Encoding::UTF_32BE).freeze,
     }.freeze
     private_constant :BOM
 

--- a/lib/psych/parser.rb
+++ b/lib/psych/parser.rb
@@ -59,7 +59,41 @@ module Psych
     # See Psych::Parser and Psych::Parser#handler
 
     def parse yaml, path = yaml.respond_to?(:path) ? yaml.path : "<unknown>"
-      _native_parse @handler, yaml, path
+      _native_parse @handler, strip_bom(yaml), path
+    end
+
+    private
+
+    BOM = {
+      Encoding::UTF_8 => "\u{FEFF}".freeze,
+      Encoding::UTF_16LE => "\u{FEFF}".encode(Encoding::UTF_16LE).freeze,
+      Encoding::UTF_16BE => "\u{FEFF}".encode(Encoding::UTF_16BE).freeze,
+    }.freeze
+    private_constant :BOM
+
+    # libyaml only skips a leading byte order mark when it detects the stream
+    # encoding by itself.  Psych passes the encoding explicitly whenever it is
+    # known, and on that path libyaml counts the BOM as a first-line character,
+    # which shifts the column of every token on the first line and silently
+    # terminates a block mapping at the second line [Bug #13615].
+    def strip_bom yaml
+      if String === yaml
+        bom = BOM[yaml.encoding]
+        return yaml[1..-1] if bom && yaml.start_with?(bom)
+      elsif yaml.respond_to?(:read) && yaml.respond_to?(:external_encoding) &&
+            yaml.respond_to?(:pos) && yaml.respond_to?(:seek)
+        bom = BOM[yaml.external_encoding]
+        skip_io_bom yaml, bom.b if bom
+      end
+      yaml
+    end
+
+    def skip_io_bom io, bom
+      pos = io.pos
+      head = io.read(bom.bytesize)
+      io.seek(pos, IO::SEEK_SET) if head && head.b != bom
+    rescue SystemCallError, IOError
+      # Not seekable; pos raises before anything is consumed.
     end
   end
 end

--- a/lib/psych/parser.rb
+++ b/lib/psych/parser.rb
@@ -89,11 +89,13 @@ module Psych
     end
 
     def skip_io_bom io, bom
-      pos = io.pos
+      begin
+        pos = io.pos
+      rescue SystemCallError, IOError
+        return # Not seekable; nothing has been consumed yet.
+      end
       head = io.read(bom.bytesize)
       io.seek(pos, IO::SEEK_SET) if head && head.b != bom
-    rescue SystemCallError, IOError
-      # Not seekable; pos raises before anything is consumed.
     end
   end
 end

--- a/test/psych/test_parser.rb
+++ b/test/psych/test_parser.rb
@@ -188,6 +188,14 @@ module Psych
       end
     end
 
+    def test_bom_multiline_utf32
+      %w[UTF-32LE UTF-32BE].each do |enc|
+        handler = EventCatcher.new
+        Psych::Parser.new(handler).parse "\uFEFFa: b\nc: d\n".encode(enc)
+        assert_equal %w[a b c d], scalars(handler), enc
+      end
+    end
+
     def test_bom_multiline_io
       @parser.parse StringIO.new("\uFEFFa: b\nc: d\n")
       assert_equal %w[a b c d], scalars(@parser.handler)

--- a/test/psych/test_parser.rb
+++ b/test/psych/test_parser.rb
@@ -173,6 +173,37 @@ module Psych
       assert_equal tadpole, @parser.handler.calls.find { |method, args| method == :scalar }[1].first
     end
 
+    # BOM + multi-line mapping used to lose every line after the first one
+    # https://github.com/ruby/psych/issues/331
+    def test_bom_multiline_utf8
+      @parser.parse "\uFEFFa: b\nc: d\n"
+      assert_equal %w[a b c d], scalars(@parser.handler)
+    end
+
+    def test_bom_multiline_utf16
+      %w[UTF-16LE UTF-16BE].each do |enc|
+        handler = EventCatcher.new
+        Psych::Parser.new(handler).parse "\uFEFFa: b\nc: d\n".encode(enc)
+        assert_equal %w[a b c d], scalars(handler), enc
+      end
+    end
+
+    def test_bom_multiline_io
+      @parser.parse StringIO.new("\uFEFFa: b\nc: d\n")
+      assert_equal %w[a b c d], scalars(@parser.handler)
+    end
+
+    def test_bom_only
+      @parser.parse "\uFEFF"
+      assert_equal [], scalars(@parser.handler)
+    end
+
+    def test_io_without_bom_is_not_modified
+      io = StringIO.new "a: b\nc: d\n".freeze
+      @parser.parse io
+      assert_equal %w[a b c d], scalars(@parser.handler)
+    end
+
     def test_external_encoding
       tadpole = 'おたまじゃくし'
 
@@ -443,6 +474,10 @@ module Psych
           end
         end
       end
+    end
+
+    def scalars handler
+      handler.calls.select { |method, _| method == :scalar }.map { |_, args| args.first }
     end
 
     def assert_called call, with = nil, parser = @parser

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -158,6 +158,16 @@ class TestPsych < Psych::TestCase
     assert_equal(%w[foo bar], docs.children.map(&:transform))
   end
 
+  # https://github.com/ruby/psych/issues/331
+  def test_load_with_leading_bom
+    assert_equal({ "a" => "b", "c" => "d" }, Psych.load("\uFEFFa: b\nc: d"))
+  end
+
+  def test_parse_stream_with_leading_bom
+    docs = Psych.parse_stream("\uFEFFa: b\nc: d")
+    assert_equal [{ "a" => "b", "c" => "d" }], docs.children.map(&:to_ruby)
+  end
+
   def test_parse_stream_with_block
     docs = []
     Psych.parse_stream("--- foo\n...\n--- bar\n...") do |node|


### PR DESCRIPTION
Fixes #331.

`YAML.load("\uFEFFa: b\nc: d")` returns `{"a" => "b"}`, silently dropping everything after the first newline, and `Psych.parse_stream` raises `Psych::SyntaxError` on the same input. A BOM at the start of the stream is legal per YAML 1.2 §5.2.

Psych tells libyaml the input encoding whenever it is known, so libyaml's reader-level BOM stripping, which only runs during encoding auto-detection, never happens. The scanner skips the BOM instead but counts it as a first-line column, so every token on the first line shifts one column right and a root-level block mapping terminates at the second line. Reported upstream as yaml/libyaml#334.

This strips the BOM at the Ruby level before the input reaches libyaml: the first character of UTF-8/UTF-16 strings, and of seekable IOs whose external encoding is one of those. Binary strings and IOs are left untouched since they go through libyaml's auto-detection, which already handles the BOM correctly. JRuby is unaffected (snakeyaml-engine excludes the BOM from column counting) and the new tests pass on both implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
